### PR TITLE
Update text-to-speech-websockets.mdx

### DIFF
--- a/api-reference/text-to-speech-websockets.mdx
+++ b/api-reference/text-to-speech-websockets.mdx
@@ -112,8 +112,8 @@ The server will always respond with a message containing the following fields:
 ```json Response message
 {
     "audio": "Y3VyaW91cyBtaW5kcyB0aGluayBhbGlrZSA6KQ==",
-    "is_final": false,
-    "normalized_alignment": {
+    "isFinal": false,
+    "normalizedAlignment": {
         "char_start_times_ms": [0, 3, 7, 9, 11, 12, 13, 15, 17, 19, 21],
         "chars_durations_ms": [3, 4, 2, 2, 1, 1, 2, 2, 2, 2, 3]
         "chars": ["H", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"]
@@ -125,11 +125,11 @@ The server will always respond with a message containing the following fields:
   A generated partial MP3 audio chunk encoded as a base64 string.
 </ResponseField>
 
-<ResponseField name="is_final" type="boolean" optional="true">
+<ResponseField name="isFinal" type="boolean" optional="true">
   Indicates if the generation is complete. If set to `True`, `audio` will be null.
 </ResponseField>
 
-<ResponseField name="normalized_alignment" type="string" optional="true">
+<ResponseField name="normalizedAlignment" type="string" optional="true">
   Alignment information for the generated audio given the input normalized text sequence.
   <Expandable title="properties">
 
@@ -300,11 +300,11 @@ socket.onmessage = function (event) {
         console.log("No audio data in the response");
     }
 
-    if (response.is_final) {
+    if (response.isFinal) {
         // the generation is complete
     }
 
-    if (response.normalized_alignment) {
+    if (response.normalizedAlignment) {
         // use the alignment info if needed
     }
 };


### PR DESCRIPTION
There are two typos in the JavaScript websockets example, its mismatching with the actual response we are getting from the elevenlabs websocket API. 

 - is_final ---> isFinal
 - normalized_alignment ---> normalizedAlignment