### PR TITLE
Fix bug in text-to-speech-stream client example

### DIFF
--- a/api-reference/text-to-speech-stream.mdx
+++ b/api-reference/text-to-speech-stream.mdx
@@ -51,7 +51,7 @@ with open('output.mp3', 'wb') as f:
 ```
 
 ```Python Client
-from elevenlabs import generate, play
+from elevenlabs import generate, stream
 
 audio = generate(
     text="Hi! My name is Bella, nice to meet you!",
@@ -60,7 +60,7 @@ audio = generate(
     stream=True
 )
 
-play(audio)
+stream(audio)
 ```
 
 </RequestExample>


### PR DESCRIPTION
The current client code crashes with the following error:

```
TypeError: memoryview: a bytes-like object is required, not 'generator'
```

Which is expected because `play` expects bytes, whereas `stream` expects a generator.

I don't know if this issue is present elsewhere in the codebase.