### PR TITLE
fix: DOCS - React Guide: Updated notes section

### DIFF
--- a/api-reference/integration-guides/react-text-to-speech-guide.mdx
+++ b/api-reference/integration-guides/react-text-to-speech-guide.mdx
@@ -1,10 +1,12 @@
 ---
-title: "React Guide"
+title: 'React Guide'
 description: "Explore natural and customizable text-to-speech synthesis for React applications with ElevenLabs' developer guide."
 ---
 
-
-<img height="200" src="/api-reference/integration-guides/images/code_stock_pexels.png" />
+<img
+  height='200'
+  src='/api-reference/integration-guides/images/code_stock_pexels.png'
+/>
 
 Image: [Pexels](https://www.pexels.com/photo/illuminated-computer-screen-4509131/)
 
@@ -16,7 +18,6 @@ What sets us apart is our ability to produce high-quality spoken audio in multip
 
 For those seeking further customization, our API even allows users to train the model [using their own voice](https://elevenlabs.io/voice-lab), opening the door to voice cloning capabilities across different languages, accents, and tones.
 
-
 ## Initializing Your Journey with ElevenLabs' Text-to-Speech API
 
 Ready to jump in? Your first step is as simple as it is crucial: obtaining your API key.
@@ -24,15 +25,15 @@ Ready to jump in? Your first step is as simple as it is crucial: obtaining your 
 ### Get an API Key
 
 1. To get started, create a free account at [ElevenLabs Signup Page](https://elevenlabs.io/sign-up). Upon successful registration, a xi-api-key will be automatically generated for you.
-2. Navigate to your profile. You’ll find your API key under your signup email address. 
+2. Navigate to your profile. You’ll find your API key under your signup email address.
 
-<img height="200" src="/api-reference/integration-guides/images/profile.png" />
+<img height='200' src='/api-reference/integration-guides/images/profile.png' />
 
 Image: [docs.elevenlabs.io](https://docs.elevenlabs.io/api-reference/quick-start/authentication)
 
 3. Click the eye icon to reveal the key as plain text for copying.
 
-<img height="200" src="/api-reference/integration-guides/images/api_key.png" />
+<img height='200' src='/api-reference/integration-guides/images/api_key.png' />
 
 Image: [docs.elevenlabs.io](https://docs.elevenlabs.io/api-reference/quick-start/authentication)
 
@@ -41,7 +42,7 @@ Image: [docs.elevenlabs.io](https://docs.elevenlabs.io/api-reference/quick-start
 
 ### Making a simple request to our API
 
-To interact with our API, you'll need to send a POST request to the following endpoint: 
+To interact with our API, you'll need to send a POST request to the following endpoint:
 
 https://api.elevenlabs.io/v1/text-to-speech/
 
@@ -61,11 +62,11 @@ First, let’s import Axios:
 import axios from 'axios';
 ```
 
-Then, let’s define a function to convert text to audio with the ElevenLabs API. We’ll call it `convertTextToAudio`, and use arrow function syntax. 
+Then, let’s define a function to convert text to audio with the ElevenLabs API. We’ll call it `convertTextToAudio`, and use arrow function syntax.
 
 The function will first define our API key (that we pull from `process.env`), and then define the ID of the voice we want to use for speech. Then, we’ll set up the syntax of the API request, add the appropriate headers, and we’re off to the races!
 
-```
+```ts
 import axios from 'axios';
 
 // Function to convert text to audio using ElevenLabs API
@@ -107,19 +108,17 @@ Once you've received the data as an ArrayBuffer from the API you can do anything
 
 First, let’s import useState and useEffect from the React library, so we can take advantage of React’s built-in function hooks:
 
-```
+```tsx
 import { useState, useEffect } from 'react';
 ```
 
 Then, we’ll define a component called AudioComponent to contain the rest of our code.
 
-```
+```tsx
 const AudioComponent = () => {
-
-  // State variable to store URL of the audio source
-  const [sourceUrl, setSourceUrl] = useState(null);
-
-}
+  // State variable to store URL of the audio source
+  const [sourceUrl, setSourceUrl] = useState(null);
+};
 ```
 
 Inside AudioComponent, we’ll create an asynchronous function called fetchAndUpdateAudioData. This function does three things:
@@ -130,7 +129,7 @@ Inside AudioComponent, we’ll create an asynchronous function called fetchAndUp
 
 Our final code is as follows:
 
-```
+```tsx
 import { useState, useEffect } from 'react';
 
 const AudioComponent = () => {
@@ -139,7 +138,7 @@ const AudioComponent = () => {
 
   // Asynchronous function to fetch audio data and update state variable
   const fetchAndUpdateAudioData = async () => {
-    const audioData = await convertTextToAudio("Hello welcome");
+    const audioData = await convertTextToAudio('Hello welcome');
 
     // Create a new Blob object from the fetched audio data with matching MIME type
     const audioBlob = new Blob([audioData], { type: 'audio/mpeg' });
@@ -161,7 +160,7 @@ const AudioComponent = () => {
     <div>
       {sourceUrl && (
         <audio autoPlay controls>
-          <source src={sourceUrl} type="audio/mpeg" />
+          <source src={sourceUrl} type='audio/mpeg' />
         </audio>
       )}
     </div>
@@ -173,10 +172,9 @@ export default AudioComponent;
 
 For more details on working with our API, including additional endpoints, refer to our [official documentation](https://api.elevenlabs.io/docs#/).
 
-
 ## Leveraging ElevenLabs' AudioStream React Component
 
-Want to take it one step further? Beyond our API, we also offer a reusable React component called `AudioStream` to facilitate text-to-speech conversion directly within your React app. 
+Want to take it one step further? Beyond our API, we also offer a reusable React component called `AudioStream` to facilitate text-to-speech conversion directly within your React app.
 
 This component requires the following props:
 
@@ -184,11 +182,10 @@ This component requires the following props:
 - `text`: The text to convert to speech (string)
 - `apiKey`: Your ElevenLabs API key (string)
 - `voiceSettings`: An object containing additional voice settings, such as stability and similarity boost (VoiceSettings)
-    
 
 For clarity, here’s the `VoiceSettings` interface:
 
-```
+```ts
 interface VoiceSettings {
   stability: number;
   similarity_boost: number;
@@ -199,25 +196,134 @@ interface VoiceSettings {
 
 Integrating `AudioStream` into your React application is a straightforward process:
 
-1. Install dependencies: First, `run npm install react react-dom @types/react @types/react-dom axios` to install the required packages.
-2. Import the component: Import `AudioStream` from its source file: `import AudioStream from './AudioStream';`
-3. Integrate into your React app: Embed the `AudioStream` component within your JSX or TSX code as shown below:
+1. Create a react project using `vite` by running `npm create vite@latest` in your terminal and follow along the instructions.
+2. Open the project in your favorite code editor and install axios by running `npm install axios` in your terminal.
+3. Create a component in your `src` directory called `AudioStream.tsx` and copy the following code into it, this is our implementation of the `AudioStream` component in it's most basic form:
 
+```tsx
+import React from 'react';
+import axios from 'axios';
+
+interface VoiceSettings {
+  stability: number;
+  similarity_boost: number;
+}
+
+interface AudioStreamProps {
+  voiceId: string;
+  text: string;
+  apiKey: string;
+  voiceSettings?: VoiceSettings;
+}
+
+const AudioStream: React.FC<AudioStreamProps> = ({
+  voiceId,
+  text,
+  apiKey,
+  voiceSettings,
+}) => {
+  const [loading, setLoading] = React.useState(false);
+
+  // State variable to store URL of the audio source
+  const [sourceUrl, setSourceUrl] = React.useState<string | null>(null);
+  const [error, setError] = React.useState('');
+
+  // Asynchronous function to fetch audio data and update state variables
+  const convertAndStream = async () => {
+    setLoading(true);
+    setError('');
+
+    const baseUrl = 'https://api.elevenlabs.io/v1/text-to-speech';
+    const headers = {
+      'Content-Type': 'application/json',
+      'xi-api-key': apiKey,
+    };
+
+    const body = {
+      text,
+      voice_settings: voiceSettings,
+    };
+
+    try {
+      const response = await axios.post(`${baseUrl}/${voiceId}`, body, {
+        headers,
+        responseType: 'blob',
+      });
+
+      if (response.status === 200) {
+        /**
+         * The response.data is a Blob object which looks like this:
+         * Blob {size: 123456, type: "audio/mpeg"}
+         */
+
+        // Create a URL for the audio blob and update the sourceUrl state variable
+        return setSourceUrl(URL.createObjectURL(response.data));
+      } else {
+        setError('Error: Unable to stream audio.');
+      }
+    } catch (error) {
+      setError('Error: Unable to stream audio.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      {/* Render an audio element when the source URL is available */}
+      {sourceUrl && (
+        <audio autoPlay controls>
+          <source src={sourceUrl} type='audio/mpeg' />
+        </audio>
+      )}
+      <button type='button' onClick={convertAndStream} disabled={loading}>
+        Convert and Stream
+      </button>
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default AudioStream;
 ```
-<AudioStream voiceId={voiceId} text={text} apiKey={apiKey} voiceSettings={voiceSettings} />
+
+4. Import the component: Import `AudioStream` from its source file: `import AudioStream from './AudioStream';` in your `App.tsx` file like so:
+
+```tsx
+import React from 'react';
+import AudioStream from './AudioStream';
+
+const voiceSettings = {
+  stability: 0,
+  similarity_boost: 0,
+};
+
+const App = () => {
+  return (
+    <div>
+      <AudioStream
+        voiceId='304fx0Tcm4TlvDq8ikWAM'
+        text='The following is an example text to test the AudioStream component.'
+        apiKey='your-api-key'
+        voiceSettings={voiceSettings}
+      />
+    </div>
+  );
+};
 ```
 
 Just replace `voiceId`, text, `apiKey`, and `voiceSettings` with the specific settings corresponding to how you’d like to use the API.
 
-Here’s an example:
+5. Here’s another example of using this reusable component:
 
-```
+```tsx
 import React from 'react';
 import ReactDOM from 'react-dom';
 import SpeechStreamComponent from './SpeechStreamComponent';
 
 const voiceSettingsId = '304fx0Tcm4TlvDq8ikWAM';
-const sampleText = 'The following is an example text to test the AudioStream component.';
+const sampleText =
+  'The following is an example text to test the AudioStream component.';
 const apiAccessKey = 'your-api-key';
 
 const audioQualitySettings = {
@@ -227,26 +333,42 @@ const audioQualitySettings = {
 
 ReactDOM.render(
   <React.StrictMode>
-    <SpeechStreamComponent voiceId={voiceSettingsId} text={sampleText} apiKey={apiAccessKey} voiceSettings={audioQualitySettings} />
+    <SpeechStreamComponent
+      voiceId={voiceSettingsId}
+      text={sampleText}
+      apiKey={apiAccessKey}
+      voiceSettings={audioQualitySettings}
+    />
   </React.StrictMode>,
   document.getElementById('root')
 );
 ```
 
-Once incorporated, the component will render with a "Start Streaming" button. Just click this button to activate the text-to-speech conversion — your generated audio should play immediately.
+Please note that the above `SpeechStreamComponent` is the same as `AudioStream` component. We have just renamed it for the sake of providing more options for naming your component.
 
+Once incorporated, the component will render an audio element with a "Start Streaming" button. Just click this button to activate the text-to-speech conversion — your generated audio should play immediately.
+
+You can also extend this reusable `AudioStream` component to add more features to it. Here are a few ideas to get you started:
+
+- Add a loading indicator to the button.
+- Use React Query to streamline the API call.
+- Add a dropdown to select the voiceIds.
+- Add a dropdown to select the voiceSettings.
+- Using Tailwind CSS or any other UI component library to style the component.
+
+These are just a few of the many ways you can customize the `AudioStream` component to suit your needs. The possibilities are endless!
 
 ## Wrapping Up
 
-At ElevenLabs, we offer an unprecedented opportunity to integrate highly natural and customizable speech synthesis into your React applications. 
+At ElevenLabs, we offer an unprecedented opportunity to integrate highly natural and customizable speech synthesis into your React applications.
 
-Whether for creating authentic voiceovers, multilingual customer service, or interactive educational modules, the ElevenLabs API and our accompanying AudioStream React component offer a robust solution to meet your text-to-speech needs. 
+Whether for creating authentic voiceovers, multilingual customer service, or interactive educational modules, the ElevenLabs API and our accompanying AudioStream React component offer a robust solution to meet your text-to-speech needs.
 
 Take the first step by signing up today and explore the authentic, real human speech capabilities that await. The possibilities are bounded only by the limits of your imagination!
 
 ### Take the Next Step with ElevenLabs
 
-Intrigued by the potential that our cutting-edge speech synthesis models can bring to your React projects? The journey doesn’t have to stop here. 
+Intrigued by the potential that our cutting-edge speech synthesis models can bring to your React projects? The journey doesn’t have to stop here.
 
 Check out ElevenLabs' [Upcoming Projects](https://elevenlabs.io/projects) to get a glimpse of the future innovations we’re working on to revolutionize your apps even further.
 

--- a/api-reference/integration-guides/react-text-to-speech-guide.mdx
+++ b/api-reference/integration-guides/react-text-to-speech-guide.mdx
@@ -346,7 +346,7 @@ ReactDOM.render(
 
 Please note that the above `SpeechStreamComponent` is the same as `AudioStream` component. We have just renamed it for the sake of providing more options for naming your component.
 
-Once incorporated, the component will render an audio element with a "Start Streaming" button. Just click this button to activate the text-to-speech conversion — your generated audio should play immediately.
+Once incorporated, the component will render an audio element with a "Convert and Stream" button. Just click this button to activate the text-to-speech conversion — your generated audio should play immediately.
 
 You can also extend this reusable `AudioStream` component to add more features to it. Here are a few ideas to get you started:
 


### PR DESCRIPTION
The PR contains changes in the [Leveraging ElevenLabs’ AudioStream React Component](https://elevenlabs.io/docs/api-reference/integration-guides/react-text-to-speech-guide#leveraging-elevenlabs-audiostream-react-component) section of the docs.

### Issues resolved:
- #79 
- #74 

### Changes:
- Updated the above mentioned section with how a user can create the `AudioStream` component and how they can use it in their app
- Added a note section explaining that `AudioStream` and `SpeechStreamComponent` components are essentially the same.
- Added a new info on how an user can extend the component
- Added syntax highlighting for the existing code blocks.