### PR TITLE
bug 62 fixed, the streamed audio is a generator not byte, need an ite…

### DIFF
--- a/api-reference/text-to-speech-stream.mdx
+++ b/api-reference/text-to-speech-stream.mdx
@@ -51,8 +51,9 @@ with open('output.mp3', 'wb') as f:
 ```
 
 ```Python Client
-from elevenlabs import generate, play
+from elevenlabs import generate, stream, play 
 
+# Provide the audio as generator of byte data using TTS.generate_stream
 audio = generate(
     text="Hi! My name is Bella, nice to meet you!",
     voice="Bella",
@@ -60,7 +61,20 @@ audio = generate(
     stream=True
 )
 
-play(audio)
+# Stream the audio directly 
+stream(audio)
+
+
+# Play the stream of the audio by iterating over each chunk
+for i,chunk in enumerate(audio):
+    play(chunk)
+
+
+# Saving the audio for later 
+with open('output.mp3', 'wb') as f:
+    for i,chunk in enumerate(audio):
+        if chunk: f.write(chunk) 
+
 ```
 
 </RequestExample>

--- a/api-reference/text-to-speech-websockets.mdx
+++ b/api-reference/text-to-speech-websockets.mdx
@@ -139,7 +139,7 @@ The server will always respond with a message containing the following fields:
 </ResponseField>
 
 <ResponseField name="normalizedAlignment" type="string" optional="true">
-  Alignment information for the generated audio given the input normalized text sequence.
+  Alignment information for the generated audio given the input normalized text sequence. This is `null` in case the text sequence is empty and there is a pause in the audio. This is the case with the presence of empty strings. 
   <Expandable title="properties">
 
   <ParamField body="char_start_times_ms" type="array">

--- a/api-reference/text-to-speech-websockets.mdx
+++ b/api-reference/text-to-speech-websockets.mdx
@@ -475,6 +475,7 @@ def text_stream():
 audio_stream = generate(
     text=text_stream(),
     voice="Nicole",
+    api_key = os.getenv("ELEVEN_LABS_API_KEY"), 
     model="eleven_monolingual_v1",
     stream=True
 )

--- a/api-reference/text-to-speech-websockets.mdx
+++ b/api-reference/text-to-speech-websockets.mdx
@@ -475,7 +475,7 @@ def text_stream():
 audio_stream = generate(
     text=text_stream(),
     voice="Nicole",
-    api_key = os.getenv("ELEVEN_LABS_API_KEY"), 
+    api_key = "api_key_here", 
     model="eleven_monolingual_v1",
     stream=True
 )


### PR DESCRIPTION
```python

from elevenlabs import generate, stream, play 

audio = generate(
    text="Hi! My name is Bella, nice to meet you!",
    voice="Bella",
    model='eleven_monolingual_v1',
    stream=True
)

# Stream the audio directly 
stream(audio)



# Saving the audio for later 
with open('output.mp3', 'wb') as f:
    for i,chunk in enumerate(audio):
        if chunk: f.write(chunk) 

```


Documentation has been updated. 