### PR TITLE
fix: DOCS - Add a key to audio element for re-render in React guide

### DIFF
--- a/api-reference/react-text-to-speech-guide.mdx
+++ b/api-reference/react-text-to-speech-guide.mdx
@@ -160,7 +160,7 @@ const AudioComponent = () => {
   return (
     <div>
       {sourceUrl && (
-        <audio autoPlay controls>
+        <audio autoPlay controls key={sourceUrl}>
           <source src={sourceUrl} type='audio/mpeg' />
         </audio>
       )}
@@ -273,7 +273,7 @@ const AudioStream: React.FC<AudioStreamProps> = ({
     <div>
       {/* Render an audio element when the source URL is available */}
       {sourceUrl && (
-        <audio autoPlay controls>
+        <audio autoPlay controls key={sourceUrl}>
           <source src={sourceUrl} type='audio/mpeg' />
         </audio>
       )}


### PR DESCRIPTION
In this AudioComponent functional component, audio element may not re-render even when sourceUrl changed, which make it a little bit confusing for React green-hands.  It results in audio source is not updating with the variable sourceUrl when a new convertTextToAudio process finish.

I suppose it's better to add an unique key props to audio element need to be updated by audio source in React. Here's also a react issue as reference.