### PR TITLE
Fix broken link to blog example on audionative

### DIFF
--- a/audio-native/overview.mdx
+++ b/audio-native/overview.mdx
@@ -40,7 +40,7 @@ It’s best not to skip any of these steps in order to understand how Audio nati
 
 
 ## Deploying Audio Native
-To see an example implementation check out our [hackathon blog post](https://elevenlabs.io/speech-synthesis).
+To see an example implementation check out our [dubbing studio blog post](https://elevenlabs.io/blog/introducing-dubbing-studio/).
 
 The embedded player automatically collects listening metrics, retention and more. Plus, it can be readily extended to any article through simple copy-pasting.
 


### PR DESCRIPTION
In our audio native docs, we say that we are linking to our blog as an example but we actually link to our speech synthesis page