### PR TITLE
fix: add JavaScript library link

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -37,6 +37,11 @@
       "url": "https://github.com/elevenlabs/elevenlabs-python"
     },
     {
+      "name": "JavaScript Library",
+      "icon": "js",
+      "url": "https://github.com/elevenlabs/elevenlabs-js"
+    },
+    {
       "name": "Community",
       "icon": "discord",
       "url": "https://discord.gg/elevenlabs"


### PR DESCRIPTION
Just adding it to show some love to the JS library 😄 
![image](https://github.com/elevenlabs/elevenlabs-docs/assets/11309999/dc7ebaa4-66b2-4535-9b5b-8ba2ec378c03)
