### PR TITLE
Fix broken link to OpenAI example in websockets.mdx

### DIFF
--- a/api-reference/websockets.mdx
+++ b/api-reference/websockets.mdx
@@ -15,7 +15,7 @@ The Text-to-Speech Websockets API is designed to generate audio from partial tex
 * The input text is being streamed or generated in chunks.
 * Word-to-audio alignment information is required.
 
-For a practical demonstration in a real world application, refer to the [Example of voice streaming using ElevenLabs and OpenAI](#example-of-voice-streaming-using-elevenlabs-and-openai) section.
+For a practical demonstration in a real world application, refer to the [Example - Voice streaming using ElevenLabs and OpenAI](#example-voice-streaming-using-elevenlabs-and-openai) section.
 
 # When not to use
 


### PR DESCRIPTION
Pls fix the broken link to OpenAI example in websockets.mdx, consider that the link does not work on GitHub previews because of '-' in the title, but it works on the website.