### PR TITLE
Remove "turbo" from speech-to-speech.mdx

### DIFF
--- a/api-reference/speech-to-speech.mdx
+++ b/api-reference/speech-to-speech.mdx
@@ -9,9 +9,6 @@ description: "Use Speech to Speech API to transform uploaded speech so it sounds
 <Card title="High-quality voices" icon="check" iconType="duotone" color="green">
   1000s of voices, in 29 languages, for every use-case, at 128kbps
 </Card>
-<Card title="Ultra-low latency" icon="check" iconType="duotone" color="green">
-  Achieve ~400ms audio generation times with our Turbo model.
-</Card>
 <Card title="Say it how you want it" icon="check" iconType="duotone" color="green">
   Full control over emotions, tone, and pronunciation.
 </Card>


### PR DESCRIPTION
The STS API does not presently support the Turbo model (`eleven_turbo_v2`), only the STS-specific models, `eleven_english_sts_v2` & `eleven_multilingual_sts_v2`. Those are the only models with `"can_do_voice_conversion": true,` at the moment.

Accordingly, the STS docs page (https://elevenlabs.io/docs/api-reference/speech-to-speech) should not mention the Turbo model and its low latency.

PS: Presumably the STS models should have "STS" in the model names, not just in the model ID? `eleven_english_sts_v2` `name` is `Eleven English v2`, `eleven_multilingual_sts_v2` `name` is `Eleven Multilingual v2` (the same as `eleven_multilingual_v2`).