### PR TITLE
Update how-to-use-request-stitching.mdx

### DIFF
--- a/api-reference/how-to-use-request-stitching.mdx
+++ b/api-reference/how-to-use-request-stitching.mdx
@@ -6,7 +6,7 @@ icon: "code"
 
 ## What is Request Stitching?
 
-When one has a large text to convert into audio and sends the text in chunks without further context there can be abrupt changes changes in prosody from one chunk to another.
+When one has a large text to convert into audio and sends the text in chunks without further context there can be abrupt changes in prosody from one chunk to another.
 
 It would be much better to give the model context on what was already generated and what will be generated in the future, this is exactly what Request Stitching does.
 


### PR DESCRIPTION
There was a typo in this documentation page "how-to-use-request-stitching.mdx". Renoved a repeated word which was not required.  