### PR TITLE
Chore: Fix URLs on Getting Started

### DIFF
--- a/api-reference/getting-started.mdx
+++ b/api-reference/getting-started.mdx
@@ -11,12 +11,8 @@ In this section, we will provide a fairly concise overview of how the API can be
 
 Something that might be good to note is that the website is just a frontend for the API. So if you use Speech Synthesis or make calls directly to the API with code, there should be no difference in quality or output with the same settings. However, the AI is still non-deterministic so there might be a difference in the delivery of the generated output.
 
-The API and the website also share the same pool of quota when generating audio. So, if you have 10,000 characters in your account and you generate audio, the characters for that generation will be deducted from your account regardless of whether you use the website or the API.
-​
-https://docs.elevenlabs.io/api-reference/
-https://api.elevenlabs.io/docs
-​
-Given the extensive nature of the API and its virtually limitless possibilities, we will only do a very quick overview and showcase a few examples to at least get you up and running.
+The API and the website also share the same pool of quota when generating audio. So, if you have 10,000 characters in your account and you generate audio, the characters for that generation will be deducted from your account regardless of whether you use the [website](https://docs.elevenlabs.io/api-reference/) or the [API.](https://api.elevenlabs.io/docs
+) Given the extensive nature of the API and its virtually limitless possibilities, we will only do a very quick overview and showcase a few examples to at least get you up and running.
 
 The [Text-To-Speech](https://elevenlabs.io/docs/api-reference/text-to-speech) (TTS) endpoint transforms text into speech in a given voice. The input consists of text, voice, and voice settings with an option to specify model.
 


### PR DESCRIPTION
Current Docs show the URLS not hyperlinked.
![image](https://github.com/elevenlabs/elevenlabs-docs/assets/45455218/f9d37efa-011b-4465-8471-b0814548fcf6)

Small Fix to change. CC @lharries
<img width="590" alt="image" src="https://github.com/elevenlabs/elevenlabs-docs/assets/45455218/71d02ce4-ea07-4111-9d2a-6d5a5da1a674">