### PR TITLE
Update models to reflect true latency

### DIFF
--- a/speech-synthesis/models.mdx
+++ b/speech-synthesis/models.mdx
@@ -27,13 +27,13 @@ There have been reports of "language switching", particularly between languages 
 
 Turbo v2.5 generates human-like text to speech in 32 languages with low latency.
 
-It’s 25% faster than Turbo v2. It's 300% faster than Multilingual v2 and adds Vietnamese, Hungarian and Swedish to our existing 29 languages.
+We recommend Turbo v2.5 for users building real time, conversational interfaces in non-English languages. It's 300% faster than Multilingual v2 and adds Vietnamese, Hungarian and Swedish to our existing 29 languages.
 
 A highly optimized model, specifically tailored for low-latency applications without sacrificing vocal performance and keeping inline with the quality standard that people have come to expect from our models.
 
 Because of its very optimized nature, it does have slightly lower accuracy than multilingual V2 and is missing the style slider, which adds latency when used. However, the accuracy is still very good when using a properly created instant voice clone, and it is very stable.
 
-We've measured latency of around 300ms consistently (+ network).
+We've measured latency as low as 300ms (+ network).
 
 We highly recommend that you test this model out!
 
@@ -43,7 +43,7 @@ A highly optimized model, specifically tailored for low-latency applications wit
 
 Because of its very optimized nature, it does have slightly lower accuracy than multilingual V2 and is missing the style slider, which adds latency when used. However, the accuracy is still very good when using a properly created instant voice clone, and it is very stable.
 
-We've measured latency of around 400ms consistently.
+For English text to speech, it's performance is on par with Turbo v2.5. 
 
 ## English v1
 


### PR DESCRIPTION
removed mention of turbo v2.5 being 25% faster