### PR TITLE
Fix invalid JSON in websockets.mdx

### DIFF
--- a/api-reference/websockets.mdx
+++ b/api-reference/websockets.mdx
@@ -150,12 +150,12 @@ The server will always respond with a message containing the following fields:
     "isFinal": false,
     "normalizedAlignment": {
         "charStartTimesMs": [0, 3, 7, 9, 11, 12, 13, 15, 17, 19, 21],
-        "charDurationsMs": [3, 4, 2, 2, 1, 1, 2, 2, 2, 2, 3]
+        "charDurationsMs": [3, 4, 2, 2, 1, 1, 2, 2, 2, 2, 3],
         "chars": ["H", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"]
     },
     "alignment": {
         "charStartTimesMs": [0, 3, 7, 9, 11, 12, 13, 15, 17, 19, 21],
-        "charDurationsMs": [3, 4, 2, 2, 1, 1, 2, 2, 2, 2, 3]
+        "charDurationsMs": [3, 4, 2, 2, 1, 1, 2, 2, 2, 2, 3],
         "chars": ["H", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"]
     }
 }


### PR DESCRIPTION
The sample response message JSON was missing a comma after the `charDurationsMs` fields for the two alignment objects in the response message.