### PR TITLE
Fix broken links in voice-selection.mdx

### DIFF
--- a/speech-synthesis/voice-selection.mdx
+++ b/speech-synthesis/voice-selection.mdx
@@ -9,10 +9,10 @@ or speech-to-speech box:
 <img width="400" height="100%" src="/voices/images/voice-select.png" />
 
 In the dropdown menu, you can select or search for multiple categories of voices:
-- <a href="/voices/default-voices">Default voices</a>
-- Generated voices created using our <a href="/voices/voice-lab/voice-design">Voice Design</a> tool
-- Cloned voices from your <a href="/voices/voice-lab/overview">VoiceLab</a>, including those added
-from the <a href="/voices/voice-library/overview">Voice Library</a>
+- <a href="/docs/voices/default-voices">Default voices</a>
+- Generated voices created using our <a href="/docs/voices/voice-lab/voice-design">Voice Design</a> tool
+- Cloned voices from your <a href="/docs/voices/voice-lab/overview">VoiceLab</a>, including those added
+from the <a href="/docs/voices/voice-library/overview">Voice Library</a>
 
 <img width="400" height="100%" src="/voices/images/default-voices.png" />
 


### PR DESCRIPTION
Add `/docs` to start of the path for the four links on the [Voice Selection page](https://elevenlabs.io/docs/speech-synthesis/voice-selection). Each of these links currently leads to a 404 without that in the link.