### PR TITLE
fix: twilio guide compatibility with updated elevenlabs-js SDK

### DIFF
--- a/api-reference/integrating-with-twilio.mdx
+++ b/api-reference/integrating-with-twilio.mdx
@@ -47,7 +47,7 @@ import ExpressWs from 'express-ws';
 import VoiceResponse from 'twilio/lib/twiml/VoiceResponse';
 import { ElevenLabsClient } from 'elevenlabs';
 import { type WebSocket } from 'ws';
-import { type Readable } from 'stream';
+import { Readable } from 'stream';
 
 const app = ExpressWs(express()).app;
 const PORT: number = parseInt(process.env.PORT || '5000');
@@ -84,7 +84,8 @@ function startApp() {
           text,
         });
 
-        const audioArrayBuffer = await streamToArrayBuffer(response);
+        const readableStream = Readable.from(response);
+        const audioArrayBuffer = await streamToArrayBuffer(readableStream);
 
         ws.send(
           JSON.stringify({
@@ -176,7 +177,8 @@ Here we listen for messages that Twilio sends to our websocket endpoint. When we
 Upon receiving the audio back from ElevenLabs, we convert it to an array buffer and send the audio to Twilio via the websocket.
 
 ```ts
-const audioArrayBuffer = await streamToArrayBuffer(response);
+const readableStream = Readable.from(response);
+const audioArrayBuffer = await streamToArrayBuffer(readableStream);
 
 ws.send(
   JSON.stringify({


### PR DESCRIPTION
The `textToSpeech.convert` method in the latest version of the `elevenlabs-js` SDK now returns a different type of stream.

- Updated the guide to convert the response from `textToSpeech.convert` into a Node.js readable stream using `Readable.from(response)`.
- This ensures the Twilio guide is compatible with the latest elevenlabs-js SDK.

Reference Issue: [elevenlabs-js/issues/90](https://github.com/elevenlabs/elevenlabs-js/issues/90)