### PR TITLE
Add text-to-voice API references

### DIFF
--- a/api-reference/ttv-create-previews.mdx
+++ b/api-reference/ttv-create-previews.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/text-to-voice/create-previews
+---

--- a/api-reference/ttv-create-voice-from-preview.mdx
+++ b/api-reference/ttv-create-voice-from-preview.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v1/text-to-voice/create-voice-from-preview
+---

--- a/mint.json
+++ b/mint.json
@@ -260,6 +260,13 @@
       ]
     },
     {
+      "group": "Text to Voice",
+      "pages": [
+        "api-reference/ttv-create-previews",
+        "api-reference/ttv-create-voice-from-preview"
+      ]
+    },
+    {
       "group": "Voice Library",
       "pages": [
         "api-reference/query-library",

--- a/openapi.json
+++ b/openapi.json
@@ -1111,6 +1111,106 @@
 				]
 			}
 		},
+        "/v1/text-to-voice/create-previews": {
+            "post": {
+              "tags": ["text-to-voice"],
+              "summary": "Generate A Voice Preview From Description",
+              "description": "Generate a custom voice based on voice description. This method returns a list of voice previews. Each preview has a generated_voice_id and a sample of the voice as base64 encoded mp3 audio. If you like the a voice previewand want to create the voice call /v1/text-to-voice/create-voice-from-preview with the generated_voice_id to create the voice.",
+              "operationId": "Generate_a_voice_preview_from_description_v1_text_to_voice_create_previews_post",
+              "parameters": [
+                {
+                  "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+                  "required": false,
+                  "schema": {
+                    "type": "string",
+                    "title": "Xi-Api-Key",
+                    "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+                  },
+                  "name": "xi-api-key",
+                  "in": "header"
+                }
+              ],
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Body_Generate_a_voice_preview_from_description_v1_text_to_voice_create_previews_post"
+                    }
+                  }
+                },
+                "required": true
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful Response",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/VoicePreviewsResponseModel"
+                      }
+                    }
+                  }
+                },
+                "422": {
+                  "description": "Validation Error",
+                  "content": {
+                    "application/json": {
+                      "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                    }
+                  }
+                }
+              }
+            }
+        },
+        "/v1/text-to-voice/create-voice-from-preview": {
+            "post": {
+              "tags": ["text-to-voice"],
+              "summary": "Create A New Voice From Voice Preview",
+              "description": "Create a voice from previously generated voice preview. This endpoint should be called after you fetched a generated_voice_id using /v1/text-to-voice/create-previews.",
+              "operationId": "Create_a_new_voice_from_voice_preview_v1_text_to_voice_create_voice_from_preview_post",
+              "parameters": [
+                {
+                  "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+                  "required": false,
+                  "schema": {
+                    "type": "string",
+                    "title": "Xi-Api-Key",
+                    "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+                  },
+                  "name": "xi-api-key",
+                  "in": "header"
+                }
+              ],
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Body_Create_a_new_voice_from_voice_preview_v1_text_to_voice_create_voice_from_preview_post"
+                    }
+                  }
+                },
+                "required": true
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful Response",
+                  "content": {
+                    "application/json": {
+                      "schema": { "$ref": "#/components/schemas/VoiceResponseModel" }
+                    }
+                  }
+                },
+                "422": {
+                  "description": "Validation Error",
+                  "content": {
+                    "application/json": {
+                      "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                    }
+                  }
+                }
+              }
+            }
+        },
 		"/v1/speech-to-speech/{voice_id}": {
 			"post": {
 				"tags": [
@@ -4786,6 +4886,100 @@
 	},
 	"components": {
 		"schemas": {
+			"Body_Create_a_new_voice_from_voice_preview_v1_text_to_voice_create_voice_from_preview_post": {
+                "properties": {
+                  "voice_name": {
+                    "type": "string",
+                    "title": "Voice Name",
+                    "description": "Name to use for the created voice.",
+                    "examples": ["Little squeaky mouse"]
+                  },
+                  "voice_description": {
+                    "type": "string",
+                    "title": "Voice Description",
+                    "description": "Description to use for the created voice.",
+                    "examples": ["A sassy little squeaky mouse"]
+                  },
+                  "generated_voice_id": {
+                    "type": "string",
+                    "title": "Generated Voice Id",
+                    "description": "The generated_voice_id to create, call POST /v1/voice-generation/generate-voice and fetch the generated_voice_id from the response header if don't have one yet.",
+                    "examples": ["37HceQefKmEi3bGovXjL"]
+                  },
+                  "labels": {
+                    "additionalProperties": { "type": "string" },
+                    "type": "object",
+                    "title": "Labels",
+                    "description": "Optional, metadata to add to the created voice. Defaults to None.",
+                    "examples": [{ "language": "en" }],
+                    "name": "Voice metadata"
+                  },
+                  "played_not_selected_voice_ids": {
+                    "items": { "type": "string" },
+                    "type": "array",
+                    "title": "Played Not Selected Voice Ids",
+                    "description": "List of voice ids that the user has played but not selected. Used for RLHF."
+                  }
+                },
+                "type": "object",
+                "required": ["voice_name", "voice_description", "generated_voice_id"],
+                "title": "Body_Create_a_new_voice_from_voice_preview_v1_text_to_voice_create_voice_from_preview_post"
+            },
+            "Body_Generate_a_voice_preview_from_description_v1_text_to_voice_create_previews_post": {
+                "properties": {
+                    "voice_description": {
+                    "type": "string",
+                    "title": "Voice Description",
+                    "description": "Description to use for the created voice.",
+                    "examples": ["A sassy little squeaky mouse"]
+                    },
+                    "text": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "minLength": 100,
+                    "title": "Text",
+                    "description": "Text to generate, text length has to be between 100 and 1000.",
+                    "examples": [
+                        "Every act of kindness, no matter how small, carries value and can make a difference, as no gesture of goodwill is ever wasted."
+                    ]
+                    }
+                },
+                "type": "object",
+                "required": ["voice_description", "text"],
+                "title": "Body_Generate_a_voice_preview_from_description_v1_text_to_voice_create_previews_post"
+            },
+            "VoicePreviewsResponseModel": {
+                "properties": {
+                  "previews": {
+                    "items": {
+                      "$ref": "#/components/schemas/VoicePreviewResponseModel"
+                    },
+                    "type": "array",
+                    "title": "Previews"
+                  }
+                },
+                "type": "object",
+                "required": ["previews"],
+                "title": "VoicePreviewsResponseModel"
+              },
+            "VoicePreviewResponseModel": {
+                "properties": {
+                  "audio_base_64": { "type": "string", "title": "Audio Base 64" },
+                  "generated_voice_id": {
+                    "type": "string",
+                    "title": "Generated Voice Id"
+                  },
+                  "media_type": {
+                    "type": "string",
+                    "enum": ["audio/mpeg"],
+                    "title": "Media Type",
+                    "default": "audio/mpeg"
+                  }
+                },
+                "type": "object",
+                "required": ["audio_base_64", "generated_voice_id"],
+                "title": "VoicePreviewResponseModel"
+            },
 			"AddChapterResponseModel": {
 				"properties": {
 					"chapter": {
@@ -5202,7 +5396,7 @@
 					"audio"
 				],
 				"title": "Body_Audio_Isolation_v1_audio_isolation_post"
-			},
+            },
 			"Body_Create_a_previously_generated_voice_v1_voice_generation_create_voice_post": {
 				"properties": {
 					"voice_name": {


### PR DESCRIPTION
- Introduce text-to-voice routes in the api documentation
[Blocked by Fern bug]
TODO:
- [x] Make TTV doc improvement suggestions
- [ ] Get feedback on proposed description/summary changes
- [ ] Update back-end with new descriptions
- [ ] Run the workflow to automatically update the OpenAPI specification once live
- [ ] Rebase this PR
---

Route: `/v1/text-to-voice/create-previews`

**Description:** Generate a voice preview from a description

**Summary:** Generates custom voice previews based on a provided voice description. The response includes a list of voice previews, each containing a `generated_voice_id` and a sample of the voice as a base64-encoded MP3 audio file. If you find a preview you like and want to create a permanent voice, use `/v1/text-to-voice/create-voice-from-preview` with the corresponding `generated_voice_id`.

---

Route: `/v1/text-to-voice/create-voice-from-preview`

**Description:** Create a new voice from a voice preview

**Summary:** Creates a new voice using a previously generated voice preview. Use this endpoint after obtaining a `generated_voice_id` from `/v1/text-to-voice/create-previews`.

---
