### PR TITLE
Add TTV docs, mark the old voice generation as deprecated

### DIFF
--- a/api-reference/generate-voice-parameters.mdx
+++ b/api-reference/generate-voice-parameters.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: get /v1/voice-generation/generate-voice/parameters
 ---
+<Warning>This API is deprecated. Please use the new [Text to Voice API](/api-reference/ttv-create-previews).</Warning>

--- a/api-reference/generate-voice.mdx
+++ b/api-reference/generate-voice.mdx
@@ -1,3 +1,4 @@
 ---
 openapi: post /v1/voice-generation/generate-voice
 ---
+<Warning>This API is deprecated. Please use the new [Text to Voice API](/api-reference/ttv-create-previews).</Warning>

--- a/api-reference/ttv-create-previews.mdx
+++ b/api-reference/ttv-create-previews.mdx
@@ -1,0 +1,4 @@
+---
+openapi: post /v1/text-to-voice/create-previews
+title: "Generate Previews from Voice Description"
+---

--- a/api-reference/ttv-create-previews.mdx
+++ b/api-reference/ttv-create-previews.mdx
@@ -2,3 +2,5 @@
 openapi: post /v1/text-to-voice/create-previews
 title: "Generate Previews from Voice Description"
 ---
+
+<Tip>Follow our [Voice Design Prompt Guide](/voices/voice-lab/voice-design#voice-design-prompt-guide) for best results.</Tip>

--- a/api-reference/ttv-create-previews.mdx
+++ b/api-reference/ttv-create-previews.mdx
@@ -1,6 +1,5 @@
 ---
 openapi: post /v1/text-to-voice/create-previews
-title: "Generate Previews from Voice Description"
 ---
 
 <Tip>Follow our [Voice Design Prompt Guide](/voices/voice-lab/voice-design#voice-design-prompt-guide) for best results.</Tip>

--- a/api-reference/ttv-create-voice-from-preview.mdx
+++ b/api-reference/ttv-create-voice-from-preview.mdx
@@ -1,4 +1,3 @@
 ---
 openapi: post /v1/text-to-voice/create-voice-from-preview
-title: "Create Voice from Preview"
 ---

--- a/api-reference/ttv-create-voice-from-preview.mdx
+++ b/api-reference/ttv-create-voice-from-preview.mdx
@@ -1,0 +1,4 @@
+---
+openapi: post /v1/text-to-voice/create-voice-from-preview
+title: "Create Voice from Preview"
+---

--- a/mint.json
+++ b/mint.json
@@ -272,10 +272,10 @@
         ]
       },
       {
-        "group": "Voice Generation",
+        "group": "Text to Voice",
         "pages": [
-          "api-reference/generate-voice",
-          "api-reference/generate-voice-parameters"
+          "api-reference/ttv-create-previews",
+          "api-reference/ttv-create-voice-from-preview"
         ]
       },
       {
@@ -350,6 +350,13 @@
         "group": "Usage",
         "pages": [
           "api-reference/usage-get-character-stats"
+        ]
+      },
+      {
+        "group": "Voice Generation (Deprecated)",
+        "pages": [
+          "api-reference/generate-voice",
+          "api-reference/generate-voice-parameters"
         ]
       },
       {

--- a/openapi.json
+++ b/openapi.json
@@ -1384,8 +1384,8 @@
 				"tags": [
 					"text-to-voice"
 				],
-				"summary": "Generate A Voice Preview From Description",
-				"description": "Generate a custom voice based on voice description. This method returns a list of voice previews. Each preview has a generated_voice_id and a sample of the voice as base64 encoded mp3 audio. If you like the a voice previewand want to create the voice call /v1/text-to-voice/create-voice-from-preview with the generated_voice_id to create the voice.",
+				"summary": "Generate Voice Previews From Description",
+				"description": "Generate custom voice previews based on provided voice description. The response includes a list of voice previews, each containing an id and a sample of the voice audio. If you like the voice preview and want to create a permanent voice, call `/v1/text-to-voice/create-voice-from-preview` with the corresponding voice id.",
 				"operationId": "Generate_a_voice_preview_from_description_v1_text_to_voice_create_previews_post",
 				"parameters": [
 					{
@@ -1504,8 +1504,8 @@
 				"tags": [
 					"text-to-voice"
 				],
-				"summary": "Create A New Voice From Voice Preview",
-				"description": "Create a voice from previously generated voice preview. This endpoint should be called after you fetched a generated_voice_id using /v1/text-to-voice/create-previews.",
+				"summary": "Create Voice From Voice Preview",
+				"description": "Create a new voice from previously generated voice preview. This endpoint should be called after you fetched a `generated_voice_id` using `/v1/text-to-voice/create-previews`.",
 				"operationId": "Create_a_new_voice_from_voice_preview_v1_text_to_voice_create_voice_from_preview_post",
 				"parameters": [
 					{
@@ -5470,7 +5470,7 @@
 					"voice_description": {
 						"type": "string",
 						"title": "Voice Description",
-						"description": "Description to use for the created voice.",
+						"description": "Description to use for the created voice. See https://elevenlabs.io/docs/voices/voice-lab/voice-design for prompting guide.",
 						"examples": [
 							"A sassy little squeaky mouse"
 						]
@@ -5478,7 +5478,7 @@
 					"generated_voice_id": {
 						"type": "string",
 						"title": "Generated Voice Id",
-						"description": "The generated_voice_id to create, call POST /v1/voice-generation/generate-voice and fetch the generated_voice_id from the response header if don't have one yet.",
+						"description": "The generated_voice_id to create, call POST /v1/text-to-voice/create-previews and fetch the generated_voice_id from the response if don't have one yet.",
 						"examples": [
 							"37HceQefKmEi3bGovXjL"
 						]
@@ -5876,7 +5876,7 @@
 						"maxLength": 1000,
 						"minLength": 100,
 						"title": "Text",
-						"description": "Text to generate, text length has to be between 100 and 1000.",
+						"description": "Text to use for generating the voice preview. Text length has to be between 100 and 1000.",
 						"examples": [
 							"Every act of kindness, no matter how small, carries value and can make a difference, as no gesture of goodwill is ever wasted."
 						]


### PR DESCRIPTION
We should update the docs in backend & clean up the examples a bit too as a follow up.