### PR TITLE
Patch in openapi changes for quality_check_on

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5338,6 +5338,11 @@
 						"title": "Callback Url",
 						"description": "[Deprecated] A url that will be called by our service when the project is converted with a json containing the status of the conversion",
 						"include_in_schema": false
+					},
+					"quality_check_on": {
+					  "type": "boolean",
+					  "title": "Quality Check On",
+					  "description": "Whether to run quality check on the generated audio and regenerate if needed."
 					}
 				},
 				"type": "object",
@@ -5791,6 +5796,11 @@
 						"title": "Volume Normalization",
 						"description": "When the project is downloaded, should the returned audio have postprocessing in order to make it compliant with audiobook normalized volume requirements",
 						"default": false
+					},
+					"quality_check_on": {
+					  "type": "boolean",
+					  "title": "Quality Check On",
+					  "description": "Whether to run quality check on the generated audio and regenerate if needed."
 					}
 				},
 				"type": "object",


### PR DESCRIPTION
The openapi.json file is manually edited right now, need to patch this in as regenerating from upstream would cause a lot of diffs. Need to fix that later.