### PR TITLE
Unnest the convai SDKs

### DIFF
--- a/conversational-ai/libraries/conversational-ai-sdk-js.mdx
+++ b/conversational-ai/libraries/conversational-ai-sdk-js.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Client SDK"
+title: "JavaScript SDK"
 description: "Conversational AI SDK: deploy customized, interactive voice agents in minutes."
 icon: "js"
 ---

--- a/mint.json
+++ b/mint.json
@@ -419,14 +419,8 @@
       "group": "Libraries & SDKs",
       "pages": [
         "conversational-ai/libraries/conversational-ai-sdk-python",
-        {
-          "group": "JavaScript SDKs",
-          "icon": "js",
-          "pages": [
-            "conversational-ai/libraries/conversational-ai-sdk-js",
-            "conversational-ai/libraries/conversational-ai-sdk-react"
-          ]
-        },
+        "conversational-ai/libraries/conversational-ai-sdk-react",
+        "conversational-ai/libraries/conversational-ai-sdk-js",
         "conversational-ai/libraries/conversational-ai-sdk-swift"
       ]
     },


### PR DESCRIPTION
Some users don't notice "javascript sdks" is expandable and there is also React SDK. I don't see an option to force it to be expanded in mintlify (will ask), in the meantime we can flatten the structure.

I've put react above js, and renamed "client" to "javascript" to keep it clearer.