### PR TITLE
chore: remove nothing audience

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -124,8 +124,6 @@ navigation:
         paginated: false
         flattened: true
         api-name: api
-        audiences:
-          - nothing
         layout:
           - page: Introduction
             path: api-reference/pages/introduction.mdx


### PR DESCRIPTION
This removes the `nothing` audience so that all the endpoints render appropriately in the API Reference 