### PR TITLE
chore: Configure Google Analytics in docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -798,3 +798,5 @@ analytics:
   posthog:
     api-key: phc_KQDh5IkRcTsPOoUtwmVxoATdOqNYCo0vTdwE77aNOQv
     endpoint: https://eu.i.posthog.com
+  ga4:
+    measurement-id: G-82RG1PXYVW

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "elevenlabs",
-  "version": "0.46.6"
+  "version": "0.46.22"
 }


### PR DESCRIPTION
Starting with Fern version 0.46.22, users can configure integration with Google Analytics and Google Tag Manager directly through their `docs.yml` file. Documentation for the new feature [available here](https://buildwithfern.com/learn/docs/integrations/analytics/google).

This allows Google Analytics integration to be managed directly by users rather than needing support from the Fern team.