### PR TITLE
fix: update docs to reflect auto-regeneration automatically applied

### DIFF
--- a/fern/product/troubleshooting/regenerations.mdx
+++ b/fern/product/troubleshooting/regenerations.mdx
@@ -37,27 +37,11 @@ If free regenerations are available for the selected paragraph or text, you will
 
 Once your free regenerations have been used, the button will return to "Generate", and you will be charged for subsequent generations.
 
-## Auto-Regenerate (Projects)
+## Auto-Regeneration for bulk conversions (Projects)
 
-When you have Auto-Regenerate enabled for your project, we will automatically check the output for any mispronunciations or unwanted audio artefacts.  If we detect any, we will automatically regenerate the audio up to twice, at no extra cost.  
+When converting a full chapter or project, auto-regeneration automatically checks the output for volume issues, voice similarity, and mispronunciations. If we detect any issues, we will automatically regenerate the audio up to twice, at no extra cost.
 
-This feature will increase the processing time, and needs to be enabled.
-
-You can either enable it in as an option in the Convert dialog window, if you're converting your project or chapter in one step, or in Project settings, which will impact individual paragraph generation.
-
-<Accordion title="How to enable in Project settings">
-Use the toggle to enable Auto-regenerate in the General tab of Project settings:
-<Frame>
-<img height="200" src="/product/troubleshooting/images/projects-auto-regen-settings.webp" />
-</Frame>
-</Accordion>
-
-<Accordion title="How to enable in Convert dialog">
-Use the toggle to enable Auto-regenerate in the Convert dialog when converting your chapter or project: 
-<Frame>
-<img height="200" src="/product/troubleshooting/images/projects-auto-regen-settings.webp" />
-</Frame>
-</Accordion>
+This feature may increase the processing time but helps ensure higher quality output for your bulk conversions.
 
 ### Feedback
 


### PR DESCRIPTION
Simple PR to reflect that auto regeneration is now only automatically applied for bulk conversion and cant be enabled otherwise.

Before: 
<img width="794" alt="Screenshot 2025-01-16 at 12 27 48" src="https://github.com/user-attachments/assets/e382bbd4-ed29-4124-a048-61256409213d" />

After:
<img width="801" alt="Screenshot 2025-01-16 at 12 30 27" src="https://github.com/user-attachments/assets/47e6f832-4b1b-45ec-8f3c-ccdf7e62d70c" />
