### PR TITLE
Docs 2.0: Voice design docs nits

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -1087,17 +1087,17 @@ paths:
         - docs
 
   # ==========================
-  # Text to Voice
+  # Voice Design (Text to voice)
   # ==========================
   /v1/text-to-voice/create-previews:
     post:
-      summary: Convert Text to Voice
-      description: Generate voices from a single text prompt.
+      summary:  Voice design
+      description: Create a voice from a text prompt.
       x-fern-audiences:
         - sdk
   /v1/text-to-voice/create-voice-from-preview:
     post:
-      summary: Save Voice from Preview
+      summary: Save a voice preview
       description: Add a generated voice to the voice library.
       x-fern-audiences:
         - sdk

--- a/fern/docs/pages/product-guides/voices/voice-design.mdx
+++ b/fern/docs/pages/product-guides/voices/voice-design.mdx
@@ -1,6 +1,6 @@
 ---
 title: Voice design
-subtitle: A guide on how to craft voices from a single prompt.
+subtitle: A guide on how to craft voices from a text prompt.
 ---
 
 <img
@@ -11,9 +11,9 @@ subtitle: A guide on how to craft voices from a single prompt.
 
 ## Overview
 
-Voice Design helps creators fill the gaps when the exact voice they are looking for isn’t available in the Voice Library. Now if you can’t find a suitable voice for your project, you can create one. Note that Voice Design is highly experimental and Professional Voice Clones are still the highest quality voices on our platform. If there is a PVC available in our library that fits your needs, we recommend using it.
+Voice Design helps creators fill the gaps when the exact voice they are looking for isn’t available in the [Voice Library](/app/voice-library). If you can’t find a suitable voice for your project, you can create one. Note that Voice Design is highly experimental and [Professional Voice Clones (PVC)](/docs/product-guides/voices/voice-cloning) are currently the highest quality voices on our platform. If there is a PVC available in our library that fits your needs, we recommend using it instead.
 
-You can find Voice Design by heading to Voices -> My Voices -> Add a new voice -> Voice Design.
+You can find Voice Design by heading to Voices -> My Voices -> Add a new voice -> Voice Design in the [ElevenLabs app](/app/voice-lab?create=true&creationType=voiceDesign) or via the [API](/docs/api-reference/text-to-voice).
 
 When you hit generate, we'll generate three voice options for you. The only charge for using voice design is the number of credits to generate your preview text, which you are only charged once even though we are generating three samples for you. You can see the number of characters that will be deducated in the "Text to preview" text box.
 

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -93,7 +93,7 @@ With your ElevenLabs API key exported as an environment variable, you're ready t
         ```
 
       </Tab>
-      <Tab title="Text to sound effects">
+      <Tab title="Sound effects">
 
         ```python Convert text into sound effects
         from elevenlabs.client import ElevenLabs
@@ -126,7 +126,7 @@ With your ElevenLabs API key exported as an environment variable, you're ready t
         ```
 
       </Tab>
-      <Tab title="Text to voice">
+      <Tab title="Voice design">
 
         ```python Generate voices from a single text prompt.
         import base64
@@ -243,7 +243,7 @@ With your ElevenLabs API key exported as an environment variable, you're ready t
         ```
 
       </Tab>
-      <Tab title="Text to sound effects">
+      <Tab title="Sound effects">
 
         ```javascript Convert text into sound effects
         import { ElevenLabsClient, play } from "elevenlabs";
@@ -281,7 +281,7 @@ With your ElevenLabs API key exported as an environment variable, you're ready t
         ```
 
       </Tab>
-      <Tab title="Text to voice">
+      <Tab title="Voice design">
 
         ```javascript Generate voices from a single text prompt.
         import { ElevenLabsClient, play } from "elevenlabs";


### PR DESCRIPTION
* Align API ref naming to product guide naming
* Add useful links to product guide
* Align quickstart naming with product naming

Todo:
[ ] Figure out how to rename `ENDPOINTS > Text to Voice` to `ENDPOINTS > Voice design`
[ ] Prevent fern from sorting endpoints alphabetically 
![image](https://github.com/user-attachments/assets/6878770f-4c3b-4f8c-ac33-a0a5e36f7309)
