### PR TITLE
Update docs to include new podcast and chapter endpoints

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -778,6 +778,13 @@ paths:
       x-fern-audiences:
         - sdk
   /v1/projects/{project_id}/chapters/{chapter_id}:
+    patch:
+      summary: Edit project chapter
+      x-fern-audiences:
+        - sdk
+      parameters:
+        - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
+        - description: The ID of the chapter to be used. You can use the [List project chapters](/docs/api-reference/chapters/get-chapters) endpoint to list all the available chapters.
     get:
       summary: Get project chapter
       x-fern-audiences:
@@ -836,14 +843,6 @@ paths:
         - sdk
       parameters:
         - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
-  /v1/projects/{project_id}/chapters/{chapter_id}:
-    patch:
-      summary: Edit project chapter
-      x-fern-audiences:
-        - sdk
-      parameters:
-        - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
-        - description: The ID of the chapter to be used. You can use the [List project chapters](/docs/api-reference/chapters/get-chapters) endpoint to list all the available chapters.
   # ======
   # MODELS
   # ======

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -817,6 +817,11 @@ paths:
         - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
         - description: The ID of the chapter to be used. You can use the [List project chapters](/docs/api-reference/chapters/get-chapters) endpoint to list all the available chapters.
         - description: The ID of the chapter snapshot to be used. You can use the [List project chapter snapshots](/docs/api-reference/chapters/get-snapshots) endpoint to list all the available snapshots.
+  /v1/projects/podcast/create:
+    post:
+      summary: Create podcast
+      x-fern-audiences:
+        - sdk
   /v1/projects/{project_id}/update-pronunciation-dictionaries:
     post:
       summary: Update pronunciation dictionaries
@@ -831,6 +836,14 @@ paths:
         - sdk
       parameters:
         - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
+  /v1/projects/{project_id}/chapters/{chapter_id}:
+    patch:
+      summary: Edit project chapter
+      x-fern-audiences:
+        - sdk
+      parameters:
+        - description: The ID of the project to be used. You can use the [List projects](/docs/api-reference/projects/get-projects) endpoint to list all the available projects.
+        - description: The ID of the chapter to be used. You can use the [List project chapters](/docs/api-reference/chapters/get-chapters) endpoint to list all the available chapters.
   # ======
   # MODELS
   # ======

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "ElevenLabs API Documentation",
-    "description": "This is the documentation for the ElevenLabs API. You can use this API to use our service programmatically, this is done by using your xi-api-key. \u003Cbr/\u003E You can view your xi-api-key using the 'Profile' tab on https://elevenlabs.io. Our API is experimental so all endpoints are subject to change.",
+    "description": "This is the documentation for the ElevenLabs API. You can use this API to use our service programmatically, this is done by using your xi-api-key. <br/> You can view your xi-api-key using the 'Profile' tab on https://elevenlabs.io. Our API is experimental so all endpoints are subject to change.",
     "version": "1.0"
   },
   "paths": {
@@ -89,9 +89,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetSpeechHistoryResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetSpeechHistoryResponseModel" }
               }
             }
           },
@@ -99,15 +97,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "history"
+        "x-fern-sdk-group-name": "history",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/history/{history_item_id}": {
@@ -146,9 +142,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SpeechHistoryItemResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/SpeechHistoryItemResponseModel" }
               }
             }
           },
@@ -156,15 +150,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "history"
+        "x-fern-sdk-group-name": "history",
+        "x-fern-sdk-method-name": "get"
       },
       "delete": {
         "tags": ["speech-history"],
@@ -199,25 +191,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete",
-        "x-fern-sdk-group-name": "history"
+        "x-fern-sdk-group-name": "history",
+        "x-fern-sdk-method-name": "delete"
       }
     },
     "/v1/history/{history_item_id}/audio": {
@@ -252,25 +238,18 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_audio",
-        "x-fern-sdk-group-name": "history"
+        "x-fern-sdk-group-name": "history",
+        "x-fern-sdk-method-name": "get_audio"
       }
     },
     "/v1/history/download": {
@@ -303,22 +282,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "download",
-        "x-fern-sdk-group-name": "history"
+        "x-fern-sdk-group-name": "history",
+        "x-fern-sdk-method-name": "download"
       }
     },
     "/v1/sound-generation": {
@@ -351,25 +326,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert",
-        "x-fern-sdk-group-name": "text_to_sound_effects"
+        "x-fern-sdk-group-name": "text_to_sound_effects",
+        "x-fern-sdk-method-name": "convert"
       }
     },
     "/v1/audio-isolation": {
@@ -402,25 +370,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "audio_isolation",
-        "x-fern-sdk-group-name": "audio_isolation"
+        "x-fern-sdk-group-name": "audio_isolation",
+        "x-fern-sdk-method-name": "audio_isolation"
       }
     },
     "/v1/audio-isolation/stream": {
@@ -453,25 +414,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "audio_isolation_stream",
-        "x-fern-sdk-group-name": "audio_isolation"
+        "x-fern-sdk-group-name": "audio_isolation",
+        "x-fern-sdk-method-name": "audio_isolation_stream"
       }
     },
     "/v1/voices/{voice_id}/samples/{sample_id}": {
@@ -520,25 +474,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete",
-        "x-fern-sdk-group-name": "samples"
+        "x-fern-sdk-group-name": "samples",
+        "x-fern-sdk-method-name": "delete"
       }
     },
     "/v1/voices/{voice_id}/samples/{sample_id}/audio": {
@@ -585,25 +533,18 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/*": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/*": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_audio",
-        "x-fern-sdk-group-name": "samples"
+        "x-fern-sdk-group-name": "samples",
+        "x-fern-sdk-method-name": "get_audio"
       }
     },
     "/v1/text-to-speech/{voice_id}": {
@@ -626,12 +567,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -684,25 +625,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert",
-        "x-fern-sdk-group-name": "text_to_speech"
+        "x-fern-sdk-group-name": "text_to_speech",
+        "x-fern-sdk-method-name": "convert"
       }
     },
     "/v1/text-to-speech/{voice_id}/with-timestamps": {
@@ -725,12 +659,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -783,25 +717,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "application/json": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert_with_timestamps",
-        "x-fern-sdk-group-name": "text_to_speech"
+        "x-fern-sdk-group-name": "text_to_speech",
+        "x-fern-sdk-method-name": "convert_with_timestamps"
       }
     },
     "/v1/text-to-speech/{voice_id}/stream": {
@@ -824,12 +751,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -882,22 +809,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert_as_stream",
-        "x-fern-sdk-group-name": "text_to_speech"
+        "x-fern-sdk-group-name": "text_to_speech",
+        "x-fern-sdk-method-name": "convert_as_stream"
       }
     },
     "/v1/text-to-speech/{voice_id}/stream/with-timestamps": {
@@ -920,12 +843,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -978,23 +901,19 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
+        "x-fern-sdk-group-name": "text_to_speech",
         "x-fern-sdk-method-name": "stream_with_timestamps",
-        "x-fern-streaming": true,
-        "x-fern-sdk-group-name": "text_to_speech"
+        "x-fern-streaming": true
       }
     },
     "/v1/speech-to-speech/{voice_id}": {
@@ -1017,12 +936,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -1075,25 +994,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert",
-        "x-fern-sdk-group-name": "speech_to_speech"
+        "x-fern-sdk-group-name": "speech_to_speech",
+        "x-fern-sdk-method-name": "convert"
       }
     },
     "/v1/speech-to-speech/{voice_id}/stream": {
@@ -1116,12 +1028,12 @@
             "in": "path"
           },
           {
-            "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+            "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
             "required": false,
             "schema": {
               "type": "boolean",
               "title": "Enable request logging.",
-              "description": "When enable_logging is set to false full privacy mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Full privacy mode may only be used by enterprise customers.",
+              "description": "When enable_logging is set to false zero retention mode will be used for the request. This will mean history features are unavailable for this request, including request stitching. Zero retention mode may only be used by enterprise customers.",
               "default": true
             },
             "name": "enable_logging",
@@ -1174,22 +1086,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert_as_stream",
-        "x-fern-sdk-group-name": "speech_to_speech"
+        "x-fern-sdk-group-name": "speech_to_speech",
+        "x-fern-sdk-method-name": "convert_as_stream"
       }
     },
     "/v1/voice-generation/generate-voice/parameters": {
@@ -1203,15 +1111,13 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceGenerationParameterResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceGenerationParameterResponseModel" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "generate_parameters",
-        "x-fern-sdk-group-name": "voice_generation"
+        "x-fern-sdk-group-name": "voice_generation",
+        "x-fern-sdk-method-name": "generate_parameters"
       }
     },
     "/v1/voice-generation/generate-voice": {
@@ -1244,25 +1150,18 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "audio/mpeg": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "audio/mpeg": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "generate",
-        "x-fern-sdk-group-name": "voice_generation"
+        "x-fern-sdk-group-name": "voice_generation",
+        "x-fern-sdk-method-name": "generate"
       }
     },
     "/v1/text-to-voice/create-previews": {
@@ -1313,9 +1212,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VoicePreviewsRequestModel"
-              }
+              "schema": { "$ref": "#/components/schemas/VoicePreviewsRequestModel" }
             }
           },
           "required": true
@@ -1325,9 +1222,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoicePreviewsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoicePreviewsResponseModel" }
               }
             }
           },
@@ -1335,15 +1230,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create_previews",
-        "x-fern-sdk-group-name": "text_to_voice"
+        "x-fern-sdk-group-name": "text_to_voice",
+        "x-fern-sdk-method-name": "create_previews"
       }
     },
     "/v1/voice-generation/create-voice": {
@@ -1380,9 +1273,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceResponseModel" }
               }
             }
           },
@@ -1390,15 +1281,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create_a_previously_generated_voice",
-        "x-fern-sdk-group-name": "voice_generation"
+        "x-fern-sdk-group-name": "voice_generation",
+        "x-fern-sdk-method-name": "create_a_previously_generated_voice"
       }
     },
     "/v1/text-to-voice/create-voice-from-preview": {
@@ -1435,9 +1324,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceResponseModel" }
               }
             }
           },
@@ -1445,15 +1332,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create_voice_from_preview",
-        "x-fern-sdk-group-name": "text_to_voice"
+        "x-fern-sdk-group-name": "text_to_voice",
+        "x-fern-sdk-method-name": "create_voice_from_preview"
       }
     },
     "/v1/user/subscription": {
@@ -1480,9 +1365,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExtendedSubscriptionResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ExtendedSubscriptionResponseModel" }
               }
             }
           },
@@ -1490,15 +1373,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_subscription",
-        "x-fern-sdk-group-name": "user"
+        "x-fern-sdk-group-name": "user",
+        "x-fern-sdk-method-name": "get_subscription"
       }
     },
     "/v1/user": {
@@ -1524,26 +1405,20 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserResponseModel"
-                }
-              }
+              "application/json": { "schema": { "$ref": "#/components/schemas/UserResponseModel" } }
             }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "user"
+        "x-fern-sdk-group-name": "user",
+        "x-fern-sdk-method-name": "get"
       }
     },
     "/v1/voices": {
@@ -1583,9 +1458,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetVoicesResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetVoicesResponseModel" }
               }
             }
           },
@@ -1593,15 +1466,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/voices/settings/default": {
@@ -1615,15 +1486,13 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceSettingsResponseModel" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_default_settings",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get_default_settings"
       }
     },
     "/v1/voices/{voice_id}/settings": {
@@ -1662,9 +1531,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceSettingsResponseModel" }
               }
             }
           },
@@ -1672,15 +1539,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_settings",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get_settings"
       }
     },
     "/v1/voices/{voice_id}": {
@@ -1731,9 +1596,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VoiceResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/VoiceResponseModel" }
               }
             }
           },
@@ -1741,15 +1604,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get"
       },
       "delete": {
         "tags": ["voices"],
@@ -1784,25 +1645,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "delete"
       }
     },
     "/v1/voices/{voice_id}/settings/edit": {
@@ -1840,11 +1695,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-                  }
-                ],
+                "allOf": [{ "$ref": "#/components/schemas/VoiceSettingsResponseModel" }],
                 "title": "Settings",
                 "description": "The settings for a specific voice."
               }
@@ -1855,25 +1706,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "edit_settings",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "edit_settings"
       }
     },
     "/v1/voices/add": {
@@ -1898,9 +1743,7 @@
         "requestBody": {
           "content": {
             "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_Add_voice_v1_voices_add_post"
-              }
+              "schema": { "$ref": "#/components/schemas/Body_Add_voice_v1_voices_add_post" }
             }
           },
           "required": true
@@ -1910,9 +1753,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddVoiceIVCResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddVoiceIVCResponseModel" }
               }
             }
           },
@@ -1920,15 +1761,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "add"
       }
     },
     "/v1/voices/{voice_id}/edit": {
@@ -1975,25 +1814,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "edit",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "edit"
       }
     },
     "/v1/voices/add/{public_user_id}/{voice_id}": {
@@ -2054,9 +1887,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddVoiceResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddVoiceResponseModel" }
               }
             }
           },
@@ -2064,15 +1895,64 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add_sharing_voice",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "add_sharing_voice"
+      }
+    },
+    "/v1/projects/podcast/create": {
+      "post": {
+        "tags": ["projects"],
+        "summary": "Create Podcast",
+        "description": "Create and auto-convert a podcast project. Currently, the LLM cost is covered by us. In the future, this cost will be passed onto you.",
+        "operationId": "Create_podcast_v1_projects_podcast_create__post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Create_podcast_v1_projects_podcast_create__post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PodcastProjectResponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "create_podcast"
       }
     },
     "/v1/projects": {
@@ -2099,9 +1979,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetProjectsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetProjectsResponseModel" }
               }
             }
           },
@@ -2109,15 +1987,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/projects/add": {
@@ -2142,9 +2018,7 @@
         "requestBody": {
           "content": {
             "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_Add_project_v1_projects_add_post"
-              }
+              "schema": { "$ref": "#/components/schemas/Body_Add_project_v1_projects_add_post" }
             }
           },
           "required": true
@@ -2154,9 +2028,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddProjectResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddProjectResponseModel" }
               }
             }
           },
@@ -2164,15 +2036,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "add"
       }
     },
     "/v1/projects/{project_id}": {
@@ -2211,9 +2081,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProjectExtendedResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ProjectExtendedResponseModel" }
               }
             }
           },
@@ -2221,15 +2089,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "get"
       },
       "post": {
         "tags": ["projects"],
@@ -2276,9 +2142,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EditProjectResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/EditProjectResponseModel" }
               }
             }
           },
@@ -2286,15 +2150,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "edit_basic_project_info",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "edit_basic_project_info"
       },
       "delete": {
         "tags": ["projects"],
@@ -2329,25 +2191,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "delete"
       }
     },
     "/v1/projects/{project_id}/content": {
@@ -2395,9 +2251,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EditProjectResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/EditProjectResponseModel" }
               }
             }
           },
@@ -2405,15 +2259,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "update_content",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "update_content"
       }
     },
     "/v1/projects/{project_id}/convert": {
@@ -2450,25 +2302,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "convert"
       }
     },
     "/v1/projects/{project_id}/snapshots": {
@@ -2507,9 +2353,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProjectSnapshotsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ProjectSnapshotsResponseModel" }
               }
             }
           },
@@ -2517,15 +2361,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_snapshots",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "get_snapshots"
       }
     },
     "/v1/projects/{project_id}/snapshots/{project_snapshot_id}/stream": {
@@ -2581,22 +2423,18 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "stream_audio",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "stream_audio"
       }
     },
     "/v1/projects/{project_id}/snapshots/{project_snapshot_id}/archive": {
@@ -2643,22 +2481,18 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "stream_archive",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "stream_archive"
       }
     },
     "/v1/projects/{project_id}/chapters": {
@@ -2697,9 +2531,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetChaptersResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetChaptersResponseModel" }
               }
             }
           },
@@ -2707,15 +2539,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/projects/{project_id}/chapters/{chapter_id}": {
@@ -2766,9 +2596,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChapterResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ChapterWithContentResponseModel" }
               }
             }
           },
@@ -2776,15 +2604,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "get"
       },
       "delete": {
         "tags": ["projects"],
@@ -2831,9 +2657,77 @@
         "responses": {
           "200": {
             "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "delete"
+      },
+      "patch": {
+        "tags": ["projects"],
+        "summary": "Edit Chapter",
+        "description": "Edits a chapter.",
+        "operationId": "Edit_chapter_v1_projects__project_id__chapters__chapter_id__patch",
+        "parameters": [
+          {
+            "description": "The project_id of the project, you can query GET https://api.elevenlabs.io/v1/projects to list all available projects.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id",
+              "description": "The project_id of the project, you can query GET https://api.elevenlabs.io/v1/projects to list all available projects."
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "project_id",
+            "in": "path"
+          },
+          {
+            "description": "The chapter_id of the chapter. You can query GET https://api.elevenlabs.io/v1/projects/{project_id}/chapters to list all available chapters for a project.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Chapter Id",
+              "description": "The chapter_id of the chapter. You can query GET https://api.elevenlabs.io/v1/projects/{project_id}/chapters to list all available chapters for a project."
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "chapter_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Edit_chapter_v1_projects__project_id__chapters__chapter_id__patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EditChapterResponseModel" }
               }
             }
           },
@@ -2841,15 +2735,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "edit"
       }
     },
     "/v1/projects/{project_id}/chapters/add": {
@@ -2898,9 +2790,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddChapterResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddChapterResponseModel" }
               }
             }
           },
@@ -2908,15 +2798,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v1/projects/{project_id}/chapters/{chapter_id}/convert": {
@@ -2965,25 +2853,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "convert",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "convert"
       }
     },
     "/v1/projects/{project_id}/chapters/{chapter_id}/snapshots": {
@@ -3034,9 +2916,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChapterSnapshotsResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ChapterSnapshotsResponseModel" }
               }
             }
           },
@@ -3044,15 +2924,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all_snapshots",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "get_all_snapshots"
       }
     },
     "/v1/projects/{project_id}/chapters/{chapter_id}/snapshots/{chapter_snapshot_id}/stream": {
@@ -3120,22 +2998,18 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "stream_snapshot",
-        "x-fern-sdk-group-name": "chapters"
+        "x-fern-sdk-group-name": "chapters",
+        "x-fern-sdk-method-name": "stream_snapshot"
       }
     },
     "/v1/projects/{project_id}/update-pronunciation-dictionaries": {
@@ -3182,25 +3056,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "update_pronunciation_dictionaries",
-        "x-fern-sdk-group-name": "projects"
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "update_pronunciation_dictionaries"
       }
     },
     "/v1/dubbing": {
@@ -3236,9 +3104,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DoDubbingResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/DoDubbingResponseModel" }
               }
             }
           },
@@ -3246,15 +3112,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "dub_a_video_or_an_audio_file",
-        "x-fern-sdk-group-name": "dubbing"
+        "x-fern-sdk-group-name": "dubbing",
+        "x-fern-sdk-method-name": "dub_a_video_or_an_audio_file"
       }
     },
     "/v1/dubbing/{dubbing_id}": {
@@ -3292,9 +3156,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DubbingMetadataResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DubbingMetadataResponse" }
               }
             }
           },
@@ -3302,15 +3164,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_dubbing_project_metadata",
-        "x-fern-sdk-group-name": "dubbing"
+        "x-fern-sdk-group-name": "dubbing",
+        "x-fern-sdk-method-name": "get_dubbing_project_metadata"
       },
       "delete": {
         "tags": ["dubbing"],
@@ -3344,25 +3204,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete_dubbing_project",
-        "x-fern-sdk-group-name": "dubbing"
+        "x-fern-sdk-group-name": "dubbing",
+        "x-fern-sdk-method-name": "delete_dubbing_project"
       }
     },
     "/v1/dubbing/{dubbing_id}/audio/{language_code}": {
@@ -3409,23 +3263,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/octet-stream": {}
-            }
+            "content": { "application/octet-stream": {} }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_dubbed_file",
-        "x-fern-sdk-group-name": "dubbing"
+        "x-fern-sdk-group-name": "dubbing",
+        "x-fern-sdk-method-name": "get_dubbed_file"
       }
     },
     "/v1/dubbing/{dubbing_id}/transcript/{language_code}": {
@@ -3486,26 +3336,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              },
-              "application/text": {}
-            }
+            "content": { "application/json": { "schema": {} }, "application/text": {} }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_dubbing_transcript",
-        "x-fern-sdk-group-name": "dubbing"
+        "x-fern-sdk-group-name": "dubbing",
+        "x-fern-sdk-method-name": "get_dubbing_transcript"
       }
     },
     "/v1/models": {
@@ -3533,9 +3376,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ModelResponseModel"
-                  },
+                  "items": { "$ref": "#/components/schemas/ModelResponseModel" },
                   "type": "array",
                   "title": "Response Get Models V1 Models Get"
                 }
@@ -3546,15 +3387,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "models"
+        "x-fern-sdk-group-name": "models",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/audio-native": {
@@ -3591,9 +3430,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AudioNativeCreateProjectResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AudioNativeCreateProjectResponseModel" }
               }
             }
           },
@@ -3601,15 +3438,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create",
-        "x-fern-sdk-group-name": "audio_native"
+        "x-fern-sdk-group-name": "audio_native",
+        "x-fern-sdk-method-name": "create"
       }
     },
     "/v1/audio-native/{project_id}/content": {
@@ -3657,7 +3492,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": { "$ref": "#/components/schemas/AudioNativeEditContentResponseModel" }
               }
             }
           },
@@ -3665,15 +3500,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "update_content",
-        "x-fern-sdk-group-name": "audio_native"
+        "x-fern-sdk-group-name": "audio_native",
+        "x-fern-sdk-method-name": "update_content"
       }
     },
     "/v1/shared-voices": {
@@ -3722,11 +3555,7 @@
           {
             "description": "age used for filtering",
             "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Age",
-              "description": "age used for filtering"
-            },
+            "schema": { "type": "string", "title": "Age", "description": "age used for filtering" },
             "example": "young",
             "name": "age",
             "in": "query"
@@ -3771,9 +3600,7 @@
             "description": "use-case used for filtering",
             "required": false,
             "schema": {
-              "items": {
-                "type": "string"
-              },
+              "items": { "type": "string" },
               "type": "array",
               "title": "Use Cases",
               "description": "use-case used for filtering"
@@ -3786,9 +3613,7 @@
             "description": "search term used for filtering",
             "required": false,
             "schema": {
-              "items": {
-                "type": "string"
-              },
+              "items": { "type": "string" },
               "type": "array",
               "title": "Descriptives",
               "description": "search term used for filtering"
@@ -3838,22 +3663,14 @@
           {
             "description": "sort criteria",
             "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Sort",
-              "description": "sort criteria"
-            },
+            "schema": { "type": "string", "title": "Sort", "description": "sort criteria" },
             "example": "created_date",
             "name": "sort",
             "in": "query"
           },
           {
             "required": false,
-            "schema": {
-              "type": "integer",
-              "title": "Page",
-              "default": 0
-            },
+            "schema": { "type": "integer", "title": "Page", "default": 0 },
             "name": "page",
             "in": "query"
           },
@@ -3874,9 +3691,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetLibraryVoicesResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetLibraryVoicesResponseModel" }
               }
             }
           },
@@ -3884,15 +3699,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_shared",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get_shared"
       }
     },
     "/v1/similar-voices": {
@@ -3928,9 +3741,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetLibraryVoicesResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetLibraryVoicesResponseModel" }
               }
             }
           },
@@ -3938,15 +3749,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_similar_library_voices",
-        "x-fern-sdk-group-name": "voices"
+        "x-fern-sdk-group-name": "voices",
+        "x-fern-sdk-method-name": "get_similar_library_voices"
       }
     },
     "/v1/usage/character-stats": {
@@ -3996,11 +3805,7 @@
             "description": "How to break down the information. Cannot be \"user\" if include_workspace_metrics is False.",
             "required": false,
             "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BreakdownTypes"
-                }
-              ],
+              "allOf": [{ "$ref": "#/components/schemas/BreakdownTypes" }],
               "description": "How to break down the information. Cannot be \"user\" if include_workspace_metrics is False.",
               "default": "none"
             },
@@ -4024,9 +3829,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UsageCharactersResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/UsageCharactersResponseModel" }
               }
             }
           },
@@ -4034,15 +3837,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_characters_usage_metrics",
-        "x-fern-sdk-group-name": "usage"
+        "x-fern-sdk-group-name": "usage",
+        "x-fern-sdk-method-name": "get_characters_usage_metrics"
       }
     },
     "/v1/pronunciation-dictionaries/add-from-file": {
@@ -4079,9 +3880,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddPronunciationDictionaryResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddPronunciationDictionaryResponseModel" }
               }
             }
           },
@@ -4089,15 +3888,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add_from_file",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "add_from_file"
       }
     },
     "/v1/pronunciation-dictionaries/{pronunciation_dictionary_id}/add-rules": {
@@ -4156,15 +3953,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add_rules",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "add_rules"
       }
     },
     "/v1/pronunciation-dictionaries/{pronunciation_dictionary_id}/remove-rules": {
@@ -4223,15 +4018,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "remove_rules",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "remove_rules"
       }
     },
     "/v1/pronunciation-dictionaries/{dictionary_id}/{version_id}/download": {
@@ -4278,25 +4071,18 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/plain": {}
-            }
-          },
+          "200": { "description": "Successful Response", "content": { "text/plain": {} } },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "download",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "download"
       }
     },
     "/v1/pronunciation-dictionaries/{pronunciation_dictionary_id}/": {
@@ -4345,15 +4131,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "get"
       }
     },
     "/v1/pronunciation-dictionaries/": {
@@ -4379,8 +4163,8 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
+              "maximum": 100.0,
+              "minimum": 1.0,
               "title": "Page Size",
               "description": "How many pronunciation dictionaries to return at maximum. Can not exceed 100, defaults to 30.",
               "default": 30
@@ -4415,15 +4199,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_all",
-        "x-fern-sdk-group-name": "pronunciation_dictionary"
+        "x-fern-sdk-group-name": "pronunciation_dictionary",
+        "x-fern-sdk-method-name": "get_all"
       }
     },
     "/v1/workspace/invites/add": {
@@ -4458,19 +4240,58 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workspace/invites/add-bulk": {
+      "post": {
+        "tags": ["workspace"],
+        "summary": "Invite Multiple Users",
+        "description": "Sends email invitations to join your workspace to the provided emails. Requires all email addresses to be part of a verified domain. If the users don't have an account they will be prompted to create one. If the users accept these invites they will be added as users to your workspace and your subscription using one of your seats. This endpoint may only be called by workspace administrators.",
+        "operationId": "Invite_multiple_users_v1_workspace_invites_add_bulk_post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Invite_multiple_users_v1_workspace_invites_add_bulk_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4509,19 +4330,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4560,19 +4375,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4604,9 +4413,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfilePageResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ProfilePageResponseModel" }
               }
             }
           },
@@ -4614,15 +4421,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get",
-        "x-fern-sdk-group-name": "profile"
+        "x-fern-sdk-group-name": "profile",
+        "x-fern-sdk-method-name": "get"
       }
     },
     "/v1/convai/conversation/get_signed_url": {
@@ -4661,9 +4466,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConversationSignedUrlResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/ConversationSignedUrlResponseModel" }
               }
             }
           },
@@ -4671,15 +4474,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_signed_url",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_signed_url"
       }
     },
     "/v1/convai/agents/create": {
@@ -4716,9 +4517,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateAgentResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/CreateAgentResponseModel" }
               }
             }
           },
@@ -4726,15 +4525,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create_agent",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "create_agent"
       }
     },
     "/v1/convai/agents/{agent_id}": {
@@ -4774,9 +4571,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAgentResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetAgentResponseModel" }
               }
             }
           },
@@ -4784,15 +4579,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_agent",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_agent"
       },
       "delete": {
         "tags": ["Conversational AI"],
@@ -4831,9 +4624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "type": "object",
                   "title": "Response Delete Agent V1 Convai Agents  Agent Id  Delete"
                 }
@@ -4844,15 +4635,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete_agent",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "delete_agent"
       },
       "patch": {
         "tags": ["Conversational AI"],
@@ -4899,9 +4688,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAgentResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetAgentResponseModel" }
               }
             }
           },
@@ -4909,15 +4696,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "update_agent",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "update_agent"
       }
     },
     "/v1/convai/agents/{agent_id}/widget": {
@@ -4968,9 +4753,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAgentEmbedResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetAgentEmbedResponseModel" }
               }
             }
           },
@@ -4978,15 +4761,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_agent_widget",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_agent_widget"
       }
     },
     "/v1/convai/agents/{agent_id}/link": {
@@ -5026,9 +4807,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAgentLinkResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetAgentLinkResponseModel" }
               }
             }
           },
@@ -5036,15 +4815,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_agent_link",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_agent_link"
       }
     },
     "/v1/convai/agents/{agent_id}/avatar": {
@@ -5094,9 +4871,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PostAgentAvatarResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/PostAgentAvatarResponseModel" }
               }
             }
           },
@@ -5104,86 +4879,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "post_agent_avatar",
-        "x-fern-sdk-group-name": "conversational_ai"
-      }
-    },
-    "/v1/convai/agents/{agent_id}/knowledge-base/{documentation_id}": {
-      "get": {
-        "tags": ["Conversational AI"],
-        "summary": "Get Documentation From Agent'S Knowledge Base",
-        "description": "Get details about a specific documentation making up the agent's knowledge base",
-        "operationId": "Get_documentation_from_Agent_s_knowledge_base_v1_convai_agents__agent_id__knowledge_base__documentation_id__get",
-        "parameters": [
-          {
-            "description": "The id of an agent. This is returned on agent creation.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id",
-              "description": "The id of an agent. This is returned on agent creation.",
-              "embed": true
-            },
-            "example": "21m00Tcm4TlvDq8ikWAM",
-            "name": "agent_id",
-            "in": "path"
-          },
-          {
-            "description": "The id of a document from the agent's knowledge base. This is returned on document addition.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Documentation Id",
-              "description": "The id of a document from the agent's knowledge base. This is returned on document addition.",
-              "embed": true
-            },
-            "example": "21m00Tcm4TlvDq8ikWAM",
-            "name": "documentation_id",
-            "in": "path"
-          },
-          {
-            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Xi-Api-Key",
-              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
-            },
-            "name": "xi-api-key",
-            "in": "header"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetKnowledgeBaseReponseModel"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-fern-sdk-method-name": "get_agent_knowledge_base_document_by_id",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "post_agent_avatar"
       }
     },
     "/v1/convai/agents/{agent_id}/add-secret": {
@@ -5233,9 +4935,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddAgentSecretResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/AddAgentSecretResponseModel" }
               }
             }
           },
@@ -5243,82 +4943,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "add_agent_secret",
-        "x-fern-sdk-group-name": "conversational_ai"
-      }
-    },
-    "/v1/convai/agents/{agent_id}/add-to-knowledge-base": {
-      "post": {
-        "tags": ["Conversational AI"],
-        "summary": "Add To Agent'S Knowledge Base",
-        "description": "Uploads a file or reference a webpage for the agent to use as part of it's knowledge base",
-        "operationId": "Add_to_Agent_s_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post",
-        "parameters": [
-          {
-            "description": "The id of an agent. This is returned on agent creation.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Id",
-              "description": "The id of an agent. This is returned on agent creation.",
-              "embed": true
-            },
-            "example": "21m00Tcm4TlvDq8ikWAM",
-            "name": "agent_id",
-            "in": "path"
-          },
-          {
-            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": "Xi-Api-Key",
-              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
-            },
-            "name": "xi-api-key",
-            "in": "header"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_Add_to_Agent_s_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AddKnowledgeBaseResponseModel"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "x-fern-sdk-method-name": "add_to_agent_knowledge_base",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "add_agent_secret"
       }
     },
     "/v1/convai/agents": {
@@ -5344,8 +4975,8 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
+              "maximum": 100.0,
+              "minimum": 1.0,
               "title": "Page Size",
               "description": "How many Agents to return at maximum. Can not exceed 100, defaults to 30.",
               "default": 30
@@ -5381,9 +5012,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetAgentsPageResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetAgentsPageResponseModel" }
               }
             }
           },
@@ -5391,15 +5020,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_agents",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_agents"
       }
     },
     "/v1/convai/conversations": {
@@ -5436,11 +5063,7 @@
             "description": "The result of the success evaluation",
             "required": false,
             "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EvaluationSuccessResult"
-                }
-              ],
+              "allOf": [{ "$ref": "#/components/schemas/EvaluationSuccessResult" }],
               "description": "The result of the success evaluation"
             },
             "example": "success",
@@ -5452,8 +5075,8 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
+              "maximum": 100.0,
+              "minimum": 1.0,
               "title": "Page Size",
               "description": "How many conversations to return at maximum. Can not exceed 100, defaults to 30.",
               "default": 30
@@ -5478,9 +5101,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetConversationsPageResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetConversationsPageResponseModel" }
               }
             }
           },
@@ -5488,15 +5109,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_conversations",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_conversations"
       }
     },
     "/v1/convai/conversations/{conversation_id}": {
@@ -5536,9 +5155,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetConversationResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetConversationResponseModel" }
               }
             }
           },
@@ -5546,15 +5163,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_conversation",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_conversation"
       },
       "delete": {
         "tags": ["Conversational AI"],
@@ -5590,25 +5205,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete_conversation",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "delete_conversation"
       }
     },
     "/v1/convai/conversations/{conversation_id}/audio": {
@@ -5644,22 +5253,18 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Successful Response"
-          },
+          "200": { "description": "Successful Response" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_conversation_audio",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_conversation_audio"
       }
     },
     "/v1/convai/conversations/{conversation_id}/feedback": {
@@ -5696,25 +5301,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "post_conversation_feedback",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "post_conversation_feedback"
       }
     },
     "/v1/convai/phone-numbers/create": {
@@ -5740,11 +5339,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreatePhoneNumberRequest"
-                  }
-                ],
+                "allOf": [{ "$ref": "#/components/schemas/CreatePhoneNumberRequest" }],
                 "title": "Phone Request",
                 "description": "Create Phone Request Information"
               }
@@ -5757,9 +5352,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreatePhoneNumberResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/CreatePhoneNumberResponseModel" }
               }
             }
           },
@@ -5767,15 +5360,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "create_phone_number",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "create_phone_number"
       }
     },
     "/v1/convai/phone-numbers/{phone_number_id}": {
@@ -5815,9 +5406,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetPhoneNumberResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetPhoneNumberResponseModel" }
               }
             }
           },
@@ -5825,15 +5414,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_phone_number",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_phone_number"
       },
       "delete": {
         "tags": ["Conversational AI"],
@@ -5869,25 +5456,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "delete_phone_number",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "delete_phone_number"
       },
       "patch": {
         "tags": ["Conversational AI"],
@@ -5924,11 +5505,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdatePhoneNumberRequest"
-                  }
-                ],
+                "allOf": [{ "$ref": "#/components/schemas/UpdatePhoneNumberRequest" }],
                 "title": "Phone Update Request",
                 "description": "Patch Phone Request Information"
               }
@@ -5941,9 +5518,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetPhoneNumberResponseModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GetPhoneNumberResponseModel" }
               }
             }
           },
@@ -5951,15 +5526,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "update_phone_number",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "update_phone_number"
       }
     },
     "/v1/convai/phone-numbers/": {
@@ -5987,9 +5560,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GetPhoneNumberResponseModel"
-                  },
+                  "items": { "$ref": "#/components/schemas/GetPhoneNumberResponseModel" },
                   "type": "array",
                   "title": "Response List Phone Numbers V1 Convai Phone Numbers  Get"
                 }
@@ -6000,15 +5571,552 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "x-fern-sdk-method-name": "get_phone_numbers",
-        "x-fern-sdk-group-name": "conversational_ai"
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_phone_numbers"
+      }
+    },
+    "/v1/convai/knowledge-base": {
+      "post": {
+        "tags": ["Conversational AI"],
+        "summary": "Add To Knowledge Base",
+        "description": "Uploads a file or reference a webpage to use as part of the shared knowledge base",
+        "operationId": "Add_to_knowledge_base_v1_convai_knowledge_base_post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Add_to_knowledge_base_v1_convai_knowledge_base_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AddKnowledgeBaseResponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "add_to_knowledge_base"
+      }
+    },
+    "/v1/convai/add-to-knowledge-base": {
+      "post": {
+        "tags": ["Conversational AI"],
+        "summary": "Add To Knowledge Base",
+        "description": "Uploads a file or reference a webpage for the agent to use as part of it's knowledge base",
+        "operationId": "Add_to_knowledge_base_v1_convai_add_to_knowledge_base_post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Add_to_knowledge_base_v1_convai_add_to_knowledge_base_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AddKnowledgeBaseResponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "add_to_knowledge_base"
+      }
+    },
+    "/v1/convai/agents/{agent_id}/add-to-knowledge-base": {
+      "post": {
+        "tags": ["Conversational AI"],
+        "summary": "Add To Knowledge Base",
+        "description": "Uploads a file or reference a webpage for the agent to use as part of it's knowledge base",
+        "operationId": "Add_to_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          },
+          {
+            "description": "The id of an agent. This is returned on agent creation.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id",
+              "description": "The id of an agent. This is returned on agent creation.",
+              "embed": true
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "agent_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_Add_to_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AddKnowledgeBaseResponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "add_to_knowledge_base"
+      }
+    },
+    "/v1/convai/knowledge-base/{documentation_id}": {
+      "get": {
+        "tags": ["Conversational AI"],
+        "summary": "Get Documentation From Knowledge Base",
+        "description": "Get details about a specific documentation making up the agent's knowledge base",
+        "operationId": "Get_documentation_from_knowledge_base_v1_convai_knowledge_base__documentation_id__get",
+        "parameters": [
+          {
+            "description": "The id of a document from the knowledge base. This is returned on document addition.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Documentation Id",
+              "description": "The id of a document from the knowledge base. This is returned on document addition.",
+              "embed": true
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "documentation_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GetKnowledgeBaseReponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_knowledge_base_document_by_id"
+      }
+    },
+    "/v1/convai/agents/{agent_id}/knowledge-base/{documentation_id}": {
+      "get": {
+        "tags": ["Conversational AI"],
+        "summary": "Get Documentation From Knowledge Base",
+        "description": "Get details about a specific documentation making up the agent's knowledge base",
+        "operationId": "Get_documentation_from_knowledge_base_v1_convai_agents__agent_id__knowledge_base__documentation_id__get",
+        "parameters": [
+          {
+            "description": "The id of a document from the knowledge base. This is returned on document addition.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Documentation Id",
+              "description": "The id of a document from the knowledge base. This is returned on document addition.",
+              "embed": true
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "documentation_id",
+            "in": "path"
+          },
+          {
+            "description": "The id of an agent. This is returned on agent creation.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id",
+              "description": "The id of an agent. This is returned on agent creation.",
+              "embed": true
+            },
+            "example": "21m00Tcm4TlvDq8ikWAM",
+            "name": "agent_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GetKnowledgeBaseReponseModel" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_knowledge_base_document_by_id"
+      }
+    },
+    "/v1/convai/add-tool": {
+      "post": {
+        "tags": ["Conversational AI"],
+        "summary": "Add Tool",
+        "description": "Add a new tool to the available tools in the workspace.",
+        "operationId": "Add_tool_v1_convai_add_tool_post",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [{ "$ref": "#/components/schemas/ToolRequestModel" }],
+                "title": "Tool",
+                "description": "A tool that an agent can provide to LLM."
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ToolResponseModel" } }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "add_tool"
+      }
+    },
+    "/v1/convai/tools/{tool_id}": {
+      "get": {
+        "tags": ["Conversational AI"],
+        "summary": "Get Tool",
+        "description": "Get tool that is available in the workspace.",
+        "operationId": "Get_tool_v1_convai_tools__tool_id__get",
+        "parameters": [
+          {
+            "description": "ID of the requested tool.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tool Id",
+              "description": "ID of the requested tool."
+            },
+            "name": "tool_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ToolResponseModel" } }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_tool"
+      },
+      "delete": {
+        "tags": ["Conversational AI"],
+        "summary": "Delete Tool",
+        "description": "Delete tool from the workspace.",
+        "operationId": "Delete_tool_v1_convai_tools__tool_id__delete",
+        "parameters": [
+          {
+            "description": "ID of the requested tool.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tool Id",
+              "description": "ID of the requested tool."
+            },
+            "name": "tool_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "remove_tool"
+      },
+      "patch": {
+        "tags": ["Conversational AI"],
+        "summary": "Update Tool",
+        "description": "Update tool that is available in the workspace.",
+        "operationId": "Update_tool_v1_convai_tools__tool_id__patch",
+        "parameters": [
+          {
+            "description": "ID of the requested tool.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tool Id",
+              "description": "ID of the requested tool."
+            },
+            "name": "tool_id",
+            "in": "path"
+          },
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [{ "$ref": "#/components/schemas/ToolRequestModel" }],
+                "title": "Tool",
+                "description": "A tool that an agent can provide to LLM."
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/ToolResponseModel" } }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "update_tool"
+      }
+    },
+    "/v1/convai/tools/": {
+      "get": {
+        "tags": ["Conversational AI"],
+        "summary": "Get Tools",
+        "description": "Get all available tools available in the workspace.",
+        "operationId": "Get_tools_v1_convai_tools__get",
+        "parameters": [
+          {
+            "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Xi-Api-Key",
+              "description": "Your API key. This is required by most endpoints to access our API programatically. You can view your xi-api-key using the 'Profile' tab on the website."
+            },
+            "name": "xi-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": { "$ref": "#/components/schemas/ToolResponseModel" },
+                  "type": "array",
+                  "title": "Response Get Tools V1 Convai Tools  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "x-fern-sdk-group-name": "conversational_ai",
+        "x-fern-sdk-method-name": "get_tools"
       }
     },
     "/docs": {
@@ -6018,11 +6126,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           }
         }
       }
@@ -6033,36 +6137,18 @@
       "ASRConversationalConfig": {
         "properties": {
           "quality": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ASRQuality"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/ASRQuality" }],
             "default": "high"
           },
           "provider": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ASRProvider"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/ASRProvider" }],
             "default": "elevenlabs"
           },
           "user_input_audio_format": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ASRInputFormat"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/ASRInputFormat" }],
             "default": "pcm_16000"
           },
-          "keywords": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Keywords"
-          }
+          "keywords": { "items": { "type": "string" }, "type": "array", "title": "Keywords" }
         },
         "type": "object",
         "title": "ASRConversationalConfig"
@@ -6087,14 +6173,8 @@
       },
       "AddAgentSecretResponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" }
         },
         "type": "object",
         "required": ["id", "name"],
@@ -6102,61 +6182,32 @@
       },
       "AddChapterResponseModel": {
         "properties": {
-          "chapter": {
-            "$ref": "#/components/schemas/ChapterResponseModel"
-          }
+          "chapter": { "$ref": "#/components/schemas/ChapterWithContentResponseModel" }
         },
         "type": "object",
         "required": ["chapter"],
         "title": "AddChapterResponseModel"
       },
       "AddKnowledgeBaseResponseModel": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          }
-        },
+        "properties": { "id": { "type": "string", "title": "Id" } },
         "type": "object",
         "required": ["id"],
         "title": "AddKnowledgeBaseResponseModel"
       },
       "AddProjectResponseModel": {
-        "properties": {
-          "project": {
-            "$ref": "#/components/schemas/ProjectResponseModel"
-          }
-        },
+        "properties": { "project": { "$ref": "#/components/schemas/ProjectResponseModel" } },
         "type": "object",
         "required": ["project"],
         "title": "AddProjectResponseModel"
       },
       "AddPronunciationDictionaryResponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "created_by": {
-            "type": "string",
-            "title": "Created By"
-          },
-          "creation_time_unix": {
-            "type": "integer",
-            "title": "Creation Time Unix"
-          },
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "creation_time_unix": { "type": "integer", "title": "Creation Time Unix" },
+          "version_id": { "type": "string", "title": "Version Id" },
+          "description": { "type": "string", "title": "Description" }
         },
         "type": "object",
         "required": ["id", "name", "created_by", "creation_time_unix", "version_id"],
@@ -6164,14 +6215,8 @@
       },
       "AddPronunciationDictionaryRulesResponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "version_id": { "type": "string", "title": "Version Id" }
         },
         "type": "object",
         "required": ["id", "version_id"],
@@ -6179,43 +6224,24 @@
       },
       "AddVoiceIVCResponseModel": {
         "properties": {
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          },
-          "requires_verification": {
-            "type": "boolean",
-            "title": "Requires Verification"
-          }
+          "voice_id": { "type": "string", "title": "Voice Id" },
+          "requires_verification": { "type": "boolean", "title": "Requires Verification" }
         },
         "type": "object",
         "required": ["voice_id", "requires_verification"],
         "title": "AddVoiceIVCResponseModel"
       },
       "AddVoiceResponseModel": {
-        "properties": {
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          }
-        },
+        "properties": { "voice_id": { "type": "string", "title": "Voice Id" } },
         "type": "object",
         "required": ["voice_id"],
         "title": "AddVoiceResponseModel"
       },
       "AgentBan": {
         "properties": {
-          "at_unix": {
-            "type": "integer",
-            "title": "At Unix"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          },
-          "reason_type": {
-            "$ref": "#/components/schemas/BanReasonType"
-          }
+          "at_unix": { "type": "integer", "title": "At Unix" },
+          "reason": { "type": "string", "title": "Reason" },
+          "reason_type": { "$ref": "#/components/schemas/BanReasonType" }
         },
         "type": "object",
         "required": ["at_unix", "reason_type"],
@@ -6228,79 +6254,42 @@
             "title": "Agent Concurrency Limit",
             "default": -1
           },
-          "daily_limit": {
-            "type": "integer",
-            "title": "Daily Limit",
-            "default": 100000
-          }
+          "daily_limit": { "type": "integer", "title": "Daily Limit", "default": 100000 }
         },
         "type": "object",
         "title": "AgentCallLimits"
       },
       "AgentConfig": {
         "properties": {
-          "prompt": {
-            "$ref": "#/components/schemas/PromptAgent"
-          },
-          "first_message": {
-            "type": "string",
-            "title": "First Message",
-            "default": ""
-          },
-          "language": {
-            "type": "string",
-            "title": "Language",
-            "default": "en"
-          },
-          "dynamic_variables": {
-            "$ref": "#/components/schemas/DynamicVariablesConfig"
-          }
+          "prompt": { "$ref": "#/components/schemas/PromptAgent" },
+          "first_message": { "type": "string", "title": "First Message", "default": "" },
+          "language": { "type": "string", "title": "Language", "default": "en" },
+          "dynamic_variables": { "$ref": "#/components/schemas/DynamicVariablesConfig" }
         },
         "type": "object",
         "title": "AgentConfig"
       },
       "AgentConfigOverride": {
         "properties": {
-          "prompt": {
-            "$ref": "#/components/schemas/PromptAgentOverride"
-          },
-          "first_message": {
-            "type": "string",
-            "title": "First Message"
-          },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          }
+          "prompt": { "$ref": "#/components/schemas/PromptAgentOverride" },
+          "first_message": { "type": "string", "title": "First Message" },
+          "language": { "type": "string", "title": "Language" }
         },
         "type": "object",
         "title": "AgentConfigOverride"
       },
       "AgentConfigOverrideConfig": {
         "properties": {
-          "prompt": {
-            "$ref": "#/components/schemas/PromptAgentOverrideConfig"
-          },
-          "first_message": {
-            "type": "boolean",
-            "title": "First Message",
-            "default": false
-          },
-          "language": {
-            "type": "boolean",
-            "title": "Language",
-            "default": false
-          }
+          "prompt": { "$ref": "#/components/schemas/PromptAgentOverrideConfig" },
+          "first_message": { "type": "boolean", "title": "First Message", "default": false },
+          "language": { "type": "boolean", "title": "Language", "default": false }
         },
         "type": "object",
         "title": "AgentConfigOverrideConfig"
       },
       "AgentMetadataResponseModel": {
         "properties": {
-          "created_at_unix_secs": {
-            "type": "integer",
-            "title": "Created At Unix Secs"
-          }
+          "created_at_unix_secs": { "type": "integer", "title": "Created At Unix Secs" }
         },
         "type": "object",
         "required": ["created_at_unix_secs"],
@@ -6308,55 +6297,28 @@
       },
       "AgentPlatformSettings": {
         "properties": {
-          "auth": {
-            "$ref": "#/components/schemas/AuthSettings"
-          },
-          "evaluation": {
-            "$ref": "#/components/schemas/EvaluationSettings"
-          },
-          "widget": {
-            "$ref": "#/components/schemas/WidgetConfig"
-          },
+          "auth": { "$ref": "#/components/schemas/AuthSettings" },
+          "evaluation": { "$ref": "#/components/schemas/EvaluationSettings" },
+          "widget": { "$ref": "#/components/schemas/WidgetConfig" },
           "data_collection": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-            },
+            "additionalProperties": { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
             "type": "object",
             "title": "Data Collection"
           },
-          "overrides": {
-            "$ref": "#/components/schemas/ConversationInitiationClientDataConfig"
-          },
-          "call_limits": {
-            "$ref": "#/components/schemas/AgentCallLimits"
-          },
-          "ban": {
-            "$ref": "#/components/schemas/AgentBan"
-          },
-          "safety": {
-            "$ref": "#/components/schemas/Safety"
-          },
-          "privacy": {
-            "$ref": "#/components/schemas/PrivacyConfig"
-          }
+          "overrides": { "$ref": "#/components/schemas/ConversationInitiationClientDataConfig" },
+          "call_limits": { "$ref": "#/components/schemas/AgentCallLimits" },
+          "ban": { "$ref": "#/components/schemas/AgentBan" },
+          "safety": { "$ref": "#/components/schemas/Safety" },
+          "privacy": { "$ref": "#/components/schemas/PrivacyConfig" }
         },
         "type": "object",
         "title": "AgentPlatformSettings"
       },
       "AgentSummaryResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "created_at_unix_secs": {
-            "type": "integer",
-            "title": "Created At Unix Secs"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "name": { "type": "string", "title": "Name" },
+          "created_at_unix_secs": { "type": "integer", "title": "Created At Unix Secs" },
           "access_level": {
             "type": "string",
             "enum": ["admin", "editor", "viewer"],
@@ -6368,43 +6330,23 @@
         "title": "AgentSummaryResponseModel"
       },
       "AllowlistItem": {
-        "properties": {
-          "hostname": {
-            "type": "string",
-            "title": "Hostname"
-          }
-        },
+        "properties": { "hostname": { "type": "string", "title": "Hostname" } },
         "type": "object",
         "required": ["hostname"],
         "title": "AllowlistItem"
       },
       "ArrayJsonSchemaProperty": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["array"],
-            "title": "Type",
-            "default": "array"
-          },
+          "type": { "type": "string", "enum": ["array"], "title": "Type", "default": "array" },
           "items": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-              },
-              {
-                "$ref": "#/components/schemas/ObjectJsonSchemaProperty"
-              },
-              {
-                "$ref": "#/components/schemas/ArrayJsonSchemaProperty"
-              }
+              { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
+              { "$ref": "#/components/schemas/ObjectJsonSchemaProperty" },
+              { "$ref": "#/components/schemas/ArrayJsonSchemaProperty" }
             ],
             "title": "Items"
           },
-          "description": {
-            "type": "string",
-            "title": "Description",
-            "default": ""
-          }
+          "description": { "type": "string", "title": "Description", "default": "" }
         },
         "additionalProperties": false,
         "type": "object",
@@ -6413,41 +6355,34 @@
       },
       "AudioNativeCreateProjectResponseModel": {
         "properties": {
-          "project_id": {
-            "type": "string",
-            "title": "Project Id"
-          },
-          "converting": {
-            "type": "boolean",
-            "title": "Converting"
-          },
-          "html_snippet": {
-            "type": "string",
-            "title": "Html Snippet"
-          }
+          "project_id": { "type": "string", "title": "Project Id" },
+          "converting": { "type": "boolean", "title": "Converting" },
+          "html_snippet": { "type": "string", "title": "Html Snippet" }
         },
         "type": "object",
         "required": ["project_id", "converting", "html_snippet"],
         "title": "AudioNativeCreateProjectResponseModel"
       },
+      "AudioNativeEditContentResponseModel": {
+        "properties": {
+          "project_id": { "type": "string", "title": "Project Id" },
+          "converting": { "type": "boolean", "title": "Converting" },
+          "publishing": { "type": "boolean", "title": "Publishing" },
+          "html_snippet": { "type": "string", "title": "Html Snippet" }
+        },
+        "type": "object",
+        "required": ["project_id", "converting", "publishing", "html_snippet"],
+        "title": "AudioNativeEditContentResponseModel"
+      },
       "AuthSettings": {
         "properties": {
-          "enable_auth": {
-            "type": "boolean",
-            "title": "Enable Auth",
-            "default": false
-          },
+          "enable_auth": { "type": "boolean", "title": "Enable Auth", "default": false },
           "allowlist": {
-            "items": {
-              "$ref": "#/components/schemas/AllowlistItem"
-            },
+            "items": { "$ref": "#/components/schemas/AllowlistItem" },
             "type": "array",
             "title": "Allowlist"
           },
-          "shareable_token": {
-            "type": "string",
-            "title": "Shareable Token"
-          }
+          "shareable_token": { "type": "string", "title": "Shareable Token" }
         },
         "type": "object",
         "title": "AuthSettings"
@@ -6582,9 +6517,7 @@
             "description": "An optional description of the project."
           },
           "genres": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Genres",
             "description": "An optional list of genres associated with the project."
@@ -6637,9 +6570,7 @@
             "default": false
           },
           "pronunciation_dictionary_locators": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Pronunciation Dictionary Locators",
             "description": "A list of pronunciation dictionary locators (pronunciation_dictionary_id, version_id) encoded as a list of JSON strings for pronunciation dictionaries to be applied to the text.  A list of json encoded strings is required as adding projects may occur through formData as opposed to jsonBody. To specify multiple dictionaries use multiple --form lines in your curl, such as --form 'pronunciation_dictionary_locators=\"{\\\"pronunciation_dictionary_id\\\":\\\"Vmd4Zor6fplcA7WrINey\\\",\\\"version_id\\\":\\\"hRPaxjlTdR7wFMhV4w0b\\\"}\"' --form 'pronunciation_dictionary_locators=\"{\\\"pronunciation_dictionary_id\\\":\\\"JzWtcGQMJ6bnlWwyMo7e\\\",\\\"version_id\\\":\\\"lbmwxiLu4q6txYxgdZqn\\\"}\"'. Note that multiple dictionaries are not currently supported by our UI which will only show the first."
@@ -6693,12 +6624,8 @@
           "rules": {
             "items": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/PronunciationDictionaryAliasRuleRequestModel"
-                },
-                {
-                  "$ref": "#/components/schemas/PronunciationDictionaryPhonemeRuleRequestModel"
-                }
+                { "$ref": "#/components/schemas/PronunciationDictionaryAliasRuleRequestModel" },
+                { "$ref": "#/components/schemas/PronunciationDictionaryPhonemeRuleRequestModel" }
               ]
             },
             "type": "array",
@@ -6722,7 +6649,7 @@
         "required": ["new_name"],
         "title": "Body_Add_sharing_voice_v1_voices_add__public_user_id___voice_id__post"
       },
-      "Body_Add_to_Agent_s_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post": {
+      "Body_Add_to_knowledge_base_v1_convai_add_to_knowledge_base_post": {
         "properties": {
           "url": {
             "type": "string",
@@ -6737,7 +6664,41 @@
           }
         },
         "type": "object",
-        "title": "Body_Add_to_Agent_s_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post"
+        "title": "Body_Add_to_knowledge_base_v1_convai_add_to_knowledge_base_post"
+      },
+      "Body_Add_to_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "URL to a page of documentation that the agent will have access to in order to interact with users."
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File",
+            "description": "Documentation that the agent will have access to in order to interact with users."
+          }
+        },
+        "type": "object",
+        "title": "Body_Add_to_knowledge_base_v1_convai_agents__agent_id__add_to_knowledge_base_post"
+      },
+      "Body_Add_to_knowledge_base_v1_convai_knowledge_base_post": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "URL to a page of documentation that the agent will have access to in order to interact with users."
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File",
+            "description": "Documentation that the agent will have access to in order to interact with users."
+          }
+        },
+        "type": "object",
+        "title": "Body_Add_to_knowledge_base_v1_convai_knowledge_base_post"
       },
       "Body_Add_voice_v1_voices_add_post": {
         "properties": {
@@ -6747,10 +6708,7 @@
             "description": "The name that identifies this voice. This will be displayed in the dropdown of the website."
           },
           "files": {
-            "items": {
-              "type": "string",
-              "format": "binary"
-            },
+            "items": { "type": "string", "format": "binary" },
             "type": "array",
             "title": "Files",
             "description": "A list of file paths to audio recordings intended for voice cloning"
@@ -6805,20 +6763,12 @@
       "Body_Create_Agent_v1_convai_agents_create_post": {
         "properties": {
           "conversation_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ConversationalConfig"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/ConversationalConfig" }],
             "title": "Conversation Config",
             "description": "Conversation configuration for an agent"
           },
           "platform_settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentPlatformSettings"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/AgentPlatformSettings" }],
             "title": "Platform Settings",
             "description": "Platform settings for the agent are all settings that aren't related to the conversation orchestration and content."
           },
@@ -6856,23 +6806,15 @@
             "examples": ["37HceQefKmEi3bGovXjL"]
           },
           "labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Labels",
             "description": "Optional, metadata to add to the created voice. Defaults to None.",
-            "examples": [
-              {
-                "language": "en"
-              }
-            ],
+            "examples": [{ "language": "en" }],
             "name": "Voice metadata"
           },
           "played_not_selected_voice_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Played Not Selected Voice Ids",
             "description": "List of voice ids that the user has played but not selected. Used for RLHF."
@@ -6903,26 +6845,18 @@
             "examples": ["37HceQefKmEi3bGovXjL"]
           },
           "played_not_selected_voice_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Played Not Selected Voice Ids",
             "description": "List of voice ids that the user has played but not selected. Used for RLHF.",
             "default": []
           },
           "labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Labels",
             "description": "Optional, metadata to add to the created voice. Defaults to None.",
-            "examples": [
-              {
-                "language": "en"
-              }
-            ],
+            "examples": [{ "language": "en" }],
             "name": "Voice metadata"
           }
         },
@@ -6930,13 +6864,72 @@
         "required": ["voice_name", "voice_description", "generated_voice_id"],
         "title": "Body_Create_a_previously_generated_voice_v1_voice_generation_create_voice_post"
       },
+      "Body_Create_podcast_v1_projects_podcast_create__post": {
+        "properties": {
+          "model_id": {
+            "type": "string",
+            "title": "Model Id",
+            "description": "The model_id of the model to be used for this project, you can query GET https://api.elevenlabs.io/v1/models to list all available models."
+          },
+          "mode": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/PodcastConversationMode" },
+              { "$ref": "#/components/schemas/PodcastBulletinMode" }
+            ],
+            "title": "Mode",
+            "description": "The type of podcast to generate"
+          },
+          "source": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/PodcastTextSource" },
+              { "$ref": "#/components/schemas/PodcastURLSource" }
+            ],
+            "title": "Source",
+            "description": "The source content for the Podcast."
+          },
+          "quality_preset": {
+            "type": "string",
+            "enum": ["standard", "high", "highest", "ultra", "ultra_lossless"],
+            "title": "Quality of the generated audio.",
+            "description": "Output quality of the generated audio. Must be one of:\nstandard - standard output format, 128kbps with 44.1kHz sample rate.\nhigh - high quality output format, 192kbps with 44.1kHz sample rate and major improvements on our side. Using this setting increases the credit cost by 20%.\nultra - ultra quality output format, 192kbps with 44.1kHz sample rate and highest improvements on our side. Using this setting increases the credit cost by 50%.\nultra lossless - ultra quality output format, 705.6kbps with 44.1kHz sample rate and highest improvements on our side in a fully lossless format. Using this setting increases the credit cost by 100%.\n",
+            "default": "standard"
+          },
+          "duration_scale": {
+            "type": "string",
+            "enum": ["short", "default", "long"],
+            "title": "The duration of the generated podcast. This varies depending on the format, voice and language.",
+            "description": "Duration of the generated podcast. Must be one of:\nshort - produces podcasts shorter than 3 minutes.\ndefault - produces podcasts roughly between 3-7 minutes.\nlong - prodces podcasts longer than 7 minutes.\n",
+            "default": "default"
+          },
+          "language": {
+            "type": "string",
+            "maxLength": 2,
+            "minLength": 2,
+            "title": "Language",
+            "description": "An optional language of the project. Two-letter language code (ISO 639-1)."
+          },
+          "highlights": {
+            "items": { "type": "string", "maxLength": 70, "minLength": 10 },
+            "type": "array",
+            "maxLength": 70,
+            "minLength": 10,
+            "title": "Highlights",
+            "description": "A brief summary or highlights of the project's content, providing key points or themes. This should be between 10 and 70 characters.",
+            "default": []
+          },
+          "callback_url": {
+            "type": "string",
+            "title": "Callback Url",
+            "description": "A url that will be called by our service when the project is converted with a json containing the status of the conversion"
+          }
+        },
+        "type": "object",
+        "required": ["model_id", "mode", "source"],
+        "title": "Body_Create_podcast_v1_projects_podcast_create__post"
+      },
       "Body_Creates_AudioNative_enabled_project__v1_audio_native_post": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Project name."
-          },
+          "name": { "type": "string", "title": "Name", "description": "Project name." },
           "image": {
             "type": "string",
             "title": "Image",
@@ -7016,9 +7009,7 @@
       "Body_Download_history_items_v1_history_download_post": {
         "properties": {
           "history_item_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "History Item Ids",
             "description": "A list of history items to download, you can get IDs of history items and other metadata using the GET https://api.elevenlabs.io/v1/history endpoint."
@@ -7154,6 +7145,22 @@
         "required": ["name", "default_title_voice_id", "default_paragraph_voice_id"],
         "title": "Body_Edit_basic_project_info_v1_projects__project_id__post"
       },
+      "Body_Edit_chapter_v1_projects__project_id__chapters__chapter_id__patch": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the chapter, used for identification only."
+          },
+          "content": {
+            "allOf": [{ "$ref": "#/components/schemas/ChapterContentInputModel" }],
+            "title": "Content",
+            "description": "The chapter content to use."
+          }
+        },
+        "type": "object",
+        "title": "Body_Edit_chapter_v1_projects__project_id__chapters__chapter_id__patch"
+      },
       "Body_Edit_project_content_v1_projects__project_id__content_post": {
         "properties": {
           "from_url": {
@@ -7185,10 +7192,7 @@
             "description": "The name that identifies this voice. This will be displayed in the dropdown of the website."
           },
           "files": {
-            "items": {
-              "type": "string",
-              "format": "binary"
-            },
+            "items": { "type": "string", "format": "binary" },
             "type": "array",
             "title": "Files",
             "description": "Audio files to add to the voice"
@@ -7255,24 +7259,40 @@
       },
       "Body_Get_similar_library_voices_v1_similar_voices_post": {
         "properties": {
-          "audio_file": {
-            "type": "string",
-            "format": "binary",
-            "title": "Audio File"
-          },
+          "audio_file": { "type": "string", "format": "binary", "title": "Audio File" },
           "similarity_threshold": {
             "type": "number",
             "title": "Similarity Threshold",
-            "description": "Threshold for voice similarity between provided sample and library voices. Must be in range \u003C0, 2\u003E. The smaller the value the more similar voices will be returned."
+            "description": "Threshold for voice similarity between provided sample and library voices. Must be in range <0, 2>. The smaller the value the more similar voices will be returned."
           },
           "top_k": {
             "type": "integer",
             "title": "Top K",
-            "description": "Number of most similar voices to return. If similarity_threshold is provided, less than this number of voices may be returned. Must be in range \u003C1, 100\u003E."
+            "description": "Number of most similar voices to return. If similarity_threshold is provided, less than this number of voices may be returned. Must be in range <1, 100>."
           }
         },
         "type": "object",
         "title": "Body_Get_similar_library_voices_v1_similar_voices_post"
+      },
+      "Body_Invite_multiple_users_v1_workspace_invites_add_bulk_post": {
+        "properties": {
+          "emails": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Emails",
+            "description": "The email of the customer"
+          },
+          "group_ids": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Group Ids",
+            "description": "The group ids of the user",
+            "examples": [["group_id_1", "group_id_2"]]
+          }
+        },
+        "type": "object",
+        "required": ["emails"],
+        "title": "Body_Invite_multiple_users_v1_workspace_invites_add_bulk_post"
       },
       "Body_Invite_user_v1_workspace_invites_add_post": {
         "properties": {
@@ -7280,6 +7300,13 @@
             "type": "string",
             "title": "Email",
             "description": "The email of the customer"
+          },
+          "group_ids": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Group Ids",
+            "description": "The group ids of the user",
+            "examples": [["group_id_1", "group_id_2"]]
           }
         },
         "type": "object",
@@ -7301,12 +7328,8 @@
           "secrets": {
             "items": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/ConvAINewSecretConfig"
-                },
-                {
-                  "$ref": "#/components/schemas/ConvAIStoredSecretConfig"
-                }
+                { "$ref": "#/components/schemas/ConvAINewSecretConfig" },
+                { "$ref": "#/components/schemas/ConvAIStoredSecretConfig" }
               ]
             },
             "type": "array",
@@ -7339,9 +7362,7 @@
       "Body_Remove_rules_from_the_pronunciation_dictionary_v1_pronunciation_dictionaries__pronunciation_dictionary_id__remove_rules_post": {
         "properties": {
           "rule_strings": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Rule Strings",
             "description": "List of strings to remove from the pronunciation dictionary."
@@ -7354,11 +7375,7 @@
       "Body_Send_Conversation_Feedback_v1_convai_conversations__conversation_id__feedback_post": {
         "properties": {
           "feedback": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UserFeedbackScore"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/UserFeedbackScore" }],
             "description": "Either 'like' or 'dislike' to indicate the feedback for the conversation."
           }
         },
@@ -7499,14 +7516,10 @@
           "language_code": {
             "type": "string",
             "title": "Language Code",
-            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 supports language enforcement. For other models, an error will be returned if language code is provided."
+            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 and Flash v2.5 support language enforcement. For other models, an error will be returned if language code is provided."
           },
           "voice_settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/VoiceSettingsResponseModel" }],
             "title": "Voice Settings",
             "description": "Voice settings overriding stored setttings for the given voice. They are applied only on the given request."
           },
@@ -7535,18 +7548,14 @@
             "description": "The text that comes after the text of the current request. Can be used to improve the flow of prosody when concatenating together multiple generations or to influence the prosody in the current generation."
           },
           "previous_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Previous Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both previous_text and previous_request_ids is send, previous_text will be ignored. A maximum of 3 request_ids can be send.",
             "default": []
           },
           "next_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Next Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both next_text and next_request_ids is send, next_text will be ignored. A maximum of 3 request_ids can be send.",
@@ -7586,14 +7595,10 @@
           "language_code": {
             "type": "string",
             "title": "Language Code",
-            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 supports language enforcement. For other models, an error will be returned if language code is provided."
+            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 and Flash v2.5 support language enforcement. For other models, an error will be returned if language code is provided."
           },
           "voice_settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/VoiceSettingsResponseModel" }],
             "title": "Voice Settings",
             "description": "Voice settings overriding stored setttings for the given voice. They are applied only on the given request."
           },
@@ -7622,18 +7627,14 @@
             "description": "The text that comes after the text of the current request. Can be used to improve the flow of prosody when concatenating together multiple generations or to influence the prosody in the current generation."
           },
           "previous_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Previous Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both previous_text and previous_request_ids is send, previous_text will be ignored. A maximum of 3 request_ids can be send.",
             "default": []
           },
           "next_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Next Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both next_text and next_request_ids is send, next_text will be ignored. A maximum of 3 request_ids can be send.",
@@ -7673,14 +7674,10 @@
           "language_code": {
             "type": "string",
             "title": "Language Code",
-            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 supports language enforcement. For other models, an error will be returned if language code is provided."
+            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 and Flash v2.5 support language enforcement. For other models, an error will be returned if language code is provided."
           },
           "voice_settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/VoiceSettingsResponseModel" }],
             "title": "Voice Settings",
             "description": "Voice settings overriding stored setttings for the given voice. They are applied only on the given request."
           },
@@ -7709,18 +7706,14 @@
             "description": "The text that comes after the text of the current request. Can be used to improve the flow of prosody when concatenating together multiple generations or to influence the prosody in the current generation."
           },
           "previous_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Previous Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both previous_text and previous_request_ids is send, previous_text will be ignored. A maximum of 3 request_ids can be send.",
             "default": []
           },
           "next_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Next Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both next_text and next_request_ids is send, next_text will be ignored. A maximum of 3 request_ids can be send.",
@@ -7760,14 +7753,10 @@
           "language_code": {
             "type": "string",
             "title": "Language Code",
-            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 supports language enforcement. For other models, an error will be returned if language code is provided."
+            "description": "Language code (ISO 639-1) used to enforce a language for the model. Currently only Turbo v2.5 and Flash v2.5 support language enforcement. For other models, an error will be returned if language code is provided."
           },
           "voice_settings": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/VoiceSettingsResponseModel" }],
             "title": "Voice Settings",
             "description": "Voice settings overriding stored setttings for the given voice. They are applied only on the given request."
           },
@@ -7796,18 +7785,14 @@
             "description": "The text that comes after the text of the current request. Can be used to improve the flow of prosody when concatenating together multiple generations or to influence the prosody in the current generation."
           },
           "previous_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Previous Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both previous_text and previous_request_ids is send, previous_text will be ignored. A maximum of 3 request_ids can be send.",
             "default": []
           },
           "next_request_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Next Request Ids",
             "description": "A list of request_id of the samples that were generated before this generation. Can be used to improve the flow of prosody when splitting up a large task into multiple requests. The results will be best when the same model is used across the generations. In case both next_text and next_request_ids is send, next_text will be ignored. A maximum of 3 request_ids can be send.",
@@ -7909,40 +7894,98 @@
         "title": "BreakdownTypes",
         "description": "How to break down the information. Cannot be \"user\" or \"api_key\" if include_workspace_metrics is False."
       },
+      "ChapterContentBlockExtendableNodeResponseModel": {
+        "properties": { "type": { "type": "string", "enum": ["_other"], "title": "Type" } },
+        "type": "object",
+        "required": ["type"],
+        "title": "ChapterContentBlockExtendableNodeResponseModel",
+        "description": "Not used. Make sure you anticipate new types in the future."
+      },
+      "ChapterContentBlockInputModel": {
+        "properties": {
+          "block_id": { "type": "string", "title": "Block Id" },
+          "nodes": {
+            "items": { "$ref": "#/components/schemas/ChapterContentParagraphTtsNodeInputModel" },
+            "type": "array",
+            "title": "Nodes"
+          }
+        },
+        "type": "object",
+        "required": ["nodes"],
+        "title": "ChapterContentBlockInputModel"
+      },
+      "ChapterContentBlockResponseModel": {
+        "properties": {
+          "block_id": { "type": "string", "title": "Block Id" },
+          "nodes": {
+            "items": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/ChapterContentBlockTtsNodeResponseModel" },
+                { "$ref": "#/components/schemas/ChapterContentBlockExtendableNodeResponseModel" }
+              ]
+            },
+            "type": "array",
+            "title": "Nodes"
+          }
+        },
+        "type": "object",
+        "required": ["block_id", "nodes"],
+        "title": "ChapterContentBlockResponseModel"
+      },
+      "ChapterContentBlockTtsNodeResponseModel": {
+        "properties": {
+          "type": { "type": "string", "enum": ["tts_node"], "title": "Type" },
+          "voice_id": { "type": "string", "title": "Voice Id" },
+          "text": { "type": "string", "title": "Text" }
+        },
+        "type": "object",
+        "required": ["type", "voice_id", "text"],
+        "title": "ChapterContentBlockTtsNodeResponseModel"
+      },
+      "ChapterContentInputModel": {
+        "properties": {
+          "blocks": {
+            "items": { "$ref": "#/components/schemas/ChapterContentBlockInputModel" },
+            "type": "array",
+            "title": "Blocks"
+          }
+        },
+        "type": "object",
+        "required": ["blocks"],
+        "title": "ChapterContentInputModel"
+      },
+      "ChapterContentParagraphTtsNodeInputModel": {
+        "properties": {
+          "type": { "type": "string", "enum": ["tts_node"], "title": "Type" },
+          "text": { "type": "string", "title": "Text" },
+          "voice_id": { "type": "string", "title": "Voice Id" }
+        },
+        "type": "object",
+        "required": ["type", "text", "voice_id"],
+        "title": "ChapterContentParagraphTtsNodeInputModel"
+      },
+      "ChapterContentResponseModel": {
+        "properties": {
+          "blocks": {
+            "items": { "$ref": "#/components/schemas/ChapterContentBlockResponseModel" },
+            "type": "array",
+            "title": "Blocks"
+          }
+        },
+        "type": "object",
+        "required": ["blocks"],
+        "title": "ChapterContentResponseModel"
+      },
       "ChapterResponseModel": {
         "properties": {
-          "chapter_id": {
-            "type": "string",
-            "title": "Chapter Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "last_conversion_date_unix": {
-            "type": "integer",
-            "title": "Last Conversion Date Unix"
-          },
-          "conversion_progress": {
-            "type": "number",
-            "title": "Conversion Progress"
-          },
-          "can_be_downloaded": {
-            "type": "boolean",
-            "title": "Can Be Downloaded"
-          },
-          "state": {
-            "type": "string",
-            "enum": ["default", "converting"],
-            "title": "State"
-          },
-          "statistics": {
-            "$ref": "#/components/schemas/ChapterStatisticsResponseModel"
-          },
-          "last_conversion_error": {
-            "type": "string",
-            "title": "Last Conversion Error"
-          }
+          "chapter_id": { "type": "string", "title": "Chapter Id" },
+          "name": { "type": "string", "title": "Name" },
+          "last_conversion_date_unix": { "type": "integer", "title": "Last Conversion Date Unix" },
+          "conversion_progress": { "type": "number", "title": "Conversion Progress" },
+          "can_be_downloaded": { "type": "boolean", "title": "Can Be Downloaded" },
+          "state": { "type": "string", "enum": ["default", "converting"], "title": "State" },
+          "statistics": { "$ref": "#/components/schemas/ChapterStatisticsResponseModel" },
+          "last_conversion_error": { "type": "string", "title": "Last Conversion Error" }
         },
         "type": "object",
         "required": ["chapter_id", "name", "can_be_downloaded", "state"],
@@ -7950,26 +7993,11 @@
       },
       "ChapterSnapshotResponseModel": {
         "properties": {
-          "chapter_snapshot_id": {
-            "type": "string",
-            "title": "Chapter Snapshot Id"
-          },
-          "project_id": {
-            "type": "string",
-            "title": "Project Id"
-          },
-          "chapter_id": {
-            "type": "string",
-            "title": "Chapter Id"
-          },
-          "created_at_unix": {
-            "type": "integer",
-            "title": "Created At Unix"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          }
+          "chapter_snapshot_id": { "type": "string", "title": "Chapter Snapshot Id" },
+          "project_id": { "type": "string", "title": "Project Id" },
+          "chapter_id": { "type": "string", "title": "Chapter Id" },
+          "created_at_unix": { "type": "integer", "title": "Created At Unix" },
+          "name": { "type": "string", "title": "Name" }
         },
         "type": "object",
         "required": ["chapter_snapshot_id", "project_id", "chapter_id", "created_at_unix", "name"],
@@ -7978,9 +8006,7 @@
       "ChapterSnapshotsResponseModel": {
         "properties": {
           "snapshots": {
-            "items": {
-              "$ref": "#/components/schemas/ChapterSnapshotResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ChapterSnapshotResponseModel" },
             "type": "array",
             "title": "Snapshots"
           }
@@ -7991,22 +8017,10 @@
       },
       "ChapterStatisticsResponseModel": {
         "properties": {
-          "characters_unconverted": {
-            "type": "integer",
-            "title": "Characters Unconverted"
-          },
-          "characters_converted": {
-            "type": "integer",
-            "title": "Characters Converted"
-          },
-          "paragraphs_converted": {
-            "type": "integer",
-            "title": "Paragraphs Converted"
-          },
-          "paragraphs_unconverted": {
-            "type": "integer",
-            "title": "Paragraphs Unconverted"
-          }
+          "characters_unconverted": { "type": "integer", "title": "Characters Unconverted" },
+          "characters_converted": { "type": "integer", "title": "Characters Converted" },
+          "paragraphs_converted": { "type": "integer", "title": "Paragraphs Converted" },
+          "paragraphs_unconverted": { "type": "integer", "title": "Paragraphs Unconverted" }
         },
         "type": "object",
         "required": [
@@ -8016,6 +8030,22 @@
           "paragraphs_unconverted"
         ],
         "title": "ChapterStatisticsResponseModel"
+      },
+      "ChapterWithContentResponseModel": {
+        "properties": {
+          "chapter_id": { "type": "string", "title": "Chapter Id" },
+          "name": { "type": "string", "title": "Name" },
+          "last_conversion_date_unix": { "type": "integer", "title": "Last Conversion Date Unix" },
+          "conversion_progress": { "type": "number", "title": "Conversion Progress" },
+          "can_be_downloaded": { "type": "boolean", "title": "Can Be Downloaded" },
+          "state": { "type": "string", "enum": ["default", "converting"], "title": "State" },
+          "statistics": { "$ref": "#/components/schemas/ChapterStatisticsResponseModel" },
+          "last_conversion_error": { "type": "string", "title": "Last Conversion Error" },
+          "content": { "$ref": "#/components/schemas/ChapterContentResponseModel" }
+        },
+        "type": "object",
+        "required": ["chapter_id", "name", "can_be_downloaded", "state", "content"],
+        "title": "ChapterWithContentResponseModel"
       },
       "ClientEvent": {
         "type": "string",
@@ -8038,32 +8068,15 @@
       },
       "ClientToolConfig": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["client"],
-            "title": "Type"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]{1,64}$",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "parameters": {
-            "$ref": "#/components/schemas/ObjectJsonSchemaProperty"
-          },
-          "expects_response": {
-            "type": "boolean",
-            "title": "Expects Response",
-            "default": false
-          },
+          "type": { "type": "string", "enum": ["client"], "title": "Type" },
+          "name": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "parameters": { "$ref": "#/components/schemas/ObjectJsonSchemaProperty" },
+          "expects_response": { "type": "boolean", "title": "Expects Response", "default": false },
           "response_timeout_secs": {
             "type": "integer",
-            "maximum": 30,
-            "minimum": 1,
+            "maximum": 30.0,
+            "minimum": 1.0,
             "title": "Response Timeout Secs"
           }
         },
@@ -8074,31 +8087,16 @@
       },
       "ConvAINewSecretConfig": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["new"],
-            "title": "Type"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "value": {
-            "type": "string",
-            "title": "Value"
-          }
+          "type": { "type": "string", "enum": ["new"], "title": "Type" },
+          "name": { "type": "string", "title": "Name" },
+          "value": { "type": "string", "title": "Value" }
         },
         "type": "object",
         "required": ["type", "name", "value"],
         "title": "ConvAINewSecretConfig"
       },
       "ConvAISecretLocator": {
-        "properties": {
-          "secret_id": {
-            "type": "string",
-            "title": "Secret Id"
-          }
-        },
+        "properties": { "secret_id": { "type": "string", "title": "Secret Id" } },
         "type": "object",
         "required": ["secret_id"],
         "title": "ConvAISecretLocator",
@@ -8106,19 +8104,9 @@
       },
       "ConvAIStoredSecretConfig": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["stored"],
-            "title": "Type"
-          },
-          "secret_id": {
-            "type": "string",
-            "title": "Secret Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          }
+          "type": { "type": "string", "enum": ["stored"], "title": "Type" },
+          "secret_id": { "type": "string", "title": "Secret Id" },
+          "name": { "type": "string", "title": "Name" }
         },
         "type": "object",
         "required": ["type", "secret_id", "name"],
@@ -8126,11 +8114,7 @@
       },
       "ConversationChargingCommonModel": {
         "properties": {
-          "dev_discount": {
-            "type": "boolean",
-            "title": "Dev Discount",
-            "default": false
-          }
+          "dev_discount": { "type": "boolean", "title": "Dev Discount", "default": false }
         },
         "type": "object",
         "title": "ConversationChargingCommonModel"
@@ -8143,9 +8127,7 @@
             "default": 600
           },
           "client_events": {
-            "items": {
-              "$ref": "#/components/schemas/ClientEvent"
-            },
+            "items": { "$ref": "#/components/schemas/ClientEvent" },
             "type": "array"
           }
         },
@@ -8154,27 +8136,44 @@
       },
       "ConversationConfigClientOverride": {
         "properties": {
-          "agent": {
-            "$ref": "#/components/schemas/AgentConfigOverride"
-          },
-          "tts": {
-            "$ref": "#/components/schemas/TTSConversationalConfigOverride"
-          }
+          "agent": { "$ref": "#/components/schemas/AgentConfigOverride" },
+          "tts": { "$ref": "#/components/schemas/TTSConversationalConfigOverride" }
         },
         "type": "object",
         "title": "ConversationConfigClientOverride"
       },
       "ConversationConfigClientOverrideConfig": {
         "properties": {
-          "agent": {
-            "$ref": "#/components/schemas/AgentConfigOverrideConfig"
-          },
-          "tts": {
-            "$ref": "#/components/schemas/TTSConversationalConfigOverrideConfig"
-          }
+          "agent": { "$ref": "#/components/schemas/AgentConfigOverrideConfig" },
+          "tts": { "$ref": "#/components/schemas/TTSConversationalConfigOverrideConfig" }
         },
         "type": "object",
         "title": "ConversationConfigClientOverrideConfig"
+      },
+      "ConversationDeletionSettings": {
+        "properties": {
+          "deletion_time_unix_secs": { "type": "integer", "title": "Deletion Time Unix Secs" },
+          "deleted_logs_at_time_unix_secs": {
+            "type": "integer",
+            "title": "Deleted Logs At Time Unix Secs"
+          },
+          "deleted_audio_at_time_unix_secs": {
+            "type": "integer",
+            "title": "Deleted Audio At Time Unix Secs"
+          },
+          "deleted_transcript_at_time_unix_secs": {
+            "type": "integer",
+            "title": "Deleted Transcript At Time Unix Secs"
+          },
+          "delete_transcript_and_pii": {
+            "type": "boolean",
+            "title": "Delete Transcript And Pii",
+            "default": false
+          },
+          "delete_audio": { "type": "boolean", "title": "Delete Audio", "default": false }
+        },
+        "type": "object",
+        "title": "ConversationDeletionSettings"
       },
       "ConversationHistoryAnalysisCommonModel": {
         "properties": {
@@ -8192,13 +8191,8 @@
             "type": "object",
             "title": "Data Collection Results"
           },
-          "call_successful": {
-            "$ref": "#/components/schemas/EvaluationSuccessResult"
-          },
-          "transcript_summary": {
-            "type": "string",
-            "title": "Transcript Summary"
-          }
+          "call_successful": { "$ref": "#/components/schemas/EvaluationSuccessResult" },
+          "transcript_summary": { "type": "string", "title": "Transcript Summary" }
         },
         "type": "object",
         "required": ["call_successful", "transcript_summary"],
@@ -8206,17 +8200,9 @@
       },
       "ConversationHistoryEvaluationCriteriaResultCommonModel": {
         "properties": {
-          "criteria_id": {
-            "type": "string",
-            "title": "Criteria Id"
-          },
-          "result": {
-            "$ref": "#/components/schemas/EvaluationSuccessResult"
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          }
+          "criteria_id": { "type": "string", "title": "Criteria Id" },
+          "result": { "$ref": "#/components/schemas/EvaluationSuccessResult" },
+          "rationale": { "type": "string", "title": "Rationale" }
         },
         "type": "object",
         "required": ["criteria_id", "result", "rationale"],
@@ -8224,56 +8210,26 @@
       },
       "ConversationHistoryFeedbackCommonModel": {
         "properties": {
-          "overall_score": {
-            "$ref": "#/components/schemas/UserFeedbackScore"
-          },
-          "likes": {
-            "type": "integer",
-            "title": "Likes",
-            "default": 0
-          },
-          "dislikes": {
-            "type": "integer",
-            "title": "Dislikes",
-            "default": 0
-          }
+          "overall_score": { "$ref": "#/components/schemas/UserFeedbackScore" },
+          "likes": { "type": "integer", "title": "Likes", "default": 0 },
+          "dislikes": { "type": "integer", "title": "Dislikes", "default": 0 }
         },
         "type": "object",
         "title": "ConversationHistoryFeedbackCommonModel"
       },
       "ConversationHistoryMetadataCommonModel": {
         "properties": {
-          "start_time_unix_secs": {
-            "type": "integer",
-            "title": "Start Time Unix Secs"
-          },
-          "call_duration_secs": {
-            "type": "integer",
-            "title": "Call Duration Secs"
-          },
-          "cost": {
-            "type": "integer",
-            "title": "Cost"
-          },
-          "feedback": {
-            "$ref": "#/components/schemas/ConversationHistoryFeedbackCommonModel"
-          },
+          "start_time_unix_secs": { "type": "integer", "title": "Start Time Unix Secs" },
+          "call_duration_secs": { "type": "integer", "title": "Call Duration Secs" },
+          "cost": { "type": "integer", "title": "Cost" },
+          "deletion_settings": { "$ref": "#/components/schemas/ConversationDeletionSettings" },
+          "feedback": { "$ref": "#/components/schemas/ConversationHistoryFeedbackCommonModel" },
           "authorization_method": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AuthorizationMethod"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/AuthorizationMethod" }],
             "default": "public"
           },
-          "charging": {
-            "$ref": "#/components/schemas/ConversationChargingCommonModel"
-          },
-          "termination_reason": {
-            "type": "string",
-            "title": "Termination Reason",
-            "default": ""
-          }
+          "charging": { "$ref": "#/components/schemas/ConversationChargingCommonModel" },
+          "termination_reason": { "type": "string", "title": "Termination Reason", "default": "" }
         },
         "type": "object",
         "required": ["start_time_unix_secs", "call_duration_secs"],
@@ -8281,15 +8237,8 @@
       },
       "ConversationHistoryTranscriptCommonModel": {
         "properties": {
-          "role": {
-            "type": "string",
-            "enum": ["user", "agent"],
-            "title": "Role"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "role": { "type": "string", "enum": ["user", "agent"], "title": "Role" },
+          "message": { "type": "string", "title": "Message" },
           "tool_calls": {
             "items": {
               "$ref": "#/components/schemas/ConversationHistoryTranscriptToolCallCommonModel"
@@ -8304,17 +8253,9 @@
             "type": "array",
             "title": "Tool Results"
           },
-          "feedback": {
-            "$ref": "#/components/schemas/UserFeedback"
-          },
-          "time_in_call_secs": {
-            "type": "integer",
-            "title": "Time In Call Secs"
-          },
-          "conversation_turn_metrics": {
-            "type": "object",
-            "title": "Conversation Turn Metrics"
-          }
+          "feedback": { "$ref": "#/components/schemas/UserFeedback" },
+          "time_in_call_secs": { "type": "integer", "title": "Time In Call Secs" },
+          "conversation_turn_metrics": { "type": "object", "title": "Conversation Turn Metrics" }
         },
         "type": "object",
         "required": ["role", "time_in_call_secs"],
@@ -8322,22 +8263,10 @@
       },
       "ConversationHistoryTranscriptToolCallCommonModel": {
         "properties": {
-          "request_id": {
-            "type": "string",
-            "title": "Request Id"
-          },
-          "tool_name": {
-            "type": "string",
-            "title": "Tool Name"
-          },
-          "params_as_json": {
-            "type": "string",
-            "title": "Params As Json"
-          },
-          "tool_has_been_called": {
-            "type": "boolean",
-            "title": "Tool Has Been Called"
-          }
+          "request_id": { "type": "string", "title": "Request Id" },
+          "tool_name": { "type": "string", "title": "Tool Name" },
+          "params_as_json": { "type": "string", "title": "Params As Json" },
+          "tool_has_been_called": { "type": "boolean", "title": "Tool Has Been Called" }
         },
         "type": "object",
         "required": ["request_id", "tool_name", "params_as_json", "tool_has_been_called"],
@@ -8345,26 +8274,11 @@
       },
       "ConversationHistoryTranscriptToolResultCommonModel": {
         "properties": {
-          "request_id": {
-            "type": "string",
-            "title": "Request Id"
-          },
-          "tool_name": {
-            "type": "string",
-            "title": "Tool Name"
-          },
-          "result_value": {
-            "type": "string",
-            "title": "Result Value"
-          },
-          "is_error": {
-            "type": "boolean",
-            "title": "Is Error"
-          },
-          "tool_has_been_called": {
-            "type": "boolean",
-            "title": "Tool Has Been Called"
-          }
+          "request_id": { "type": "string", "title": "Request Id" },
+          "tool_name": { "type": "string", "title": "Tool Name" },
+          "result_value": { "type": "string", "title": "Result Value" },
+          "is_error": { "type": "boolean", "title": "Is Error" },
+          "tool_has_been_called": { "type": "boolean", "title": "Tool Has Been Called" }
         },
         "type": "object",
         "required": ["request_id", "tool_name", "result_value", "is_error", "tool_has_been_called"],
@@ -8375,25 +8289,14 @@
           "conversation_config_override": {
             "$ref": "#/components/schemas/ConversationConfigClientOverride"
           },
-          "custom_llm_extra_body": {
-            "type": "object",
-            "title": "Custom Llm Extra Body"
-          },
+          "custom_llm_extra_body": { "type": "object", "title": "Custom Llm Extra Body" },
           "dynamic_variables": {
             "additionalProperties": {
               "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                }
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "integer" },
+                { "type": "boolean" }
               ]
             },
             "type": "object",
@@ -8418,50 +8321,21 @@
         "title": "ConversationInitiationClientDataConfig"
       },
       "ConversationSignedUrlResponseModel": {
-        "properties": {
-          "signed_url": {
-            "type": "string",
-            "title": "Signed Url"
-          }
-        },
+        "properties": { "signed_url": { "type": "string", "title": "Signed Url" } },
         "type": "object",
         "required": ["signed_url"],
         "title": "ConversationSignedUrlResponseModel"
       },
       "ConversationSummaryResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "conversation_id": {
-            "type": "string",
-            "title": "Conversation Id"
-          },
-          "start_time_unix_secs": {
-            "type": "integer",
-            "title": "Start Time Unix Secs"
-          },
-          "call_duration_secs": {
-            "type": "integer",
-            "title": "Call Duration Secs"
-          },
-          "message_count": {
-            "type": "integer",
-            "title": "Message Count"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["processing", "done"],
-            "title": "Status"
-          },
-          "call_successful": {
-            "$ref": "#/components/schemas/EvaluationSuccessResult"
-          }
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "conversation_id": { "type": "string", "title": "Conversation Id" },
+          "start_time_unix_secs": { "type": "integer", "title": "Start Time Unix Secs" },
+          "call_duration_secs": { "type": "integer", "title": "Call Duration Secs" },
+          "message_count": { "type": "integer", "title": "Message Count" },
+          "status": { "type": "string", "enum": ["processing", "done"], "title": "Status" },
+          "call_successful": { "$ref": "#/components/schemas/EvaluationSuccessResult" }
         },
         "type": "object",
         "required": [
@@ -8477,24 +8351,11 @@
       },
       "ConversationTokenDBModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "conversation_token": {
-            "type": "string",
-            "title": "Conversation Token"
-          },
-          "expiration_time_unix_secs": {
-            "type": "integer",
-            "title": "Expiration Time Unix Secs"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "conversation_token": { "type": "string", "title": "Conversation Token" },
+          "expiration_time_unix_secs": { "type": "integer", "title": "Expiration Time Unix Secs" },
           "purpose": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ConversationTokenPurpose"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/ConversationTokenPurpose" }],
             "default": "signed_url"
           }
         },
@@ -8510,25 +8371,13 @@
       },
       "ConversationalConfig": {
         "properties": {
-          "agent": {
-            "$ref": "#/components/schemas/AgentConfig"
-          },
-          "asr": {
-            "$ref": "#/components/schemas/ASRConversationalConfig"
-          },
-          "turn": {
-            "$ref": "#/components/schemas/TurnConfig"
-          },
-          "tts": {
-            "$ref": "#/components/schemas/TTSConversationalConfig"
-          },
-          "conversation": {
-            "$ref": "#/components/schemas/ConversationConfig"
-          },
+          "agent": { "$ref": "#/components/schemas/AgentConfig" },
+          "asr": { "$ref": "#/components/schemas/ASRConversationalConfig" },
+          "turn": { "$ref": "#/components/schemas/TurnConfig" },
+          "tts": { "$ref": "#/components/schemas/TTSConversationalConfig" },
+          "conversation": { "$ref": "#/components/schemas/ConversationConfig" },
           "language_presets": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LanguagePreset"
-            },
+            "additionalProperties": { "$ref": "#/components/schemas/LanguagePreset" },
             "type": "object",
             "title": "Language Presets"
           }
@@ -8537,12 +8386,7 @@
         "title": "ConversationalConfig"
       },
       "CreateAgentResponseModel": {
-        "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          }
-        },
+        "properties": { "agent_id": { "type": "string", "title": "Agent Id" } },
         "type": "object",
         "required": ["agent_id"],
         "title": "CreateAgentResponseModel"
@@ -8555,11 +8399,7 @@
             "description": "Phone number"
           },
           "provider": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TelephonyProvider"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/TelephonyProvider" }],
             "description": "Phone provider"
           },
           "label": {
@@ -8567,16 +8407,8 @@
             "title": "Label",
             "description": "Label for the phone number"
           },
-          "sid": {
-            "type": "string",
-            "title": "Sid",
-            "description": "Twilio Account SID"
-          },
-          "token": {
-            "type": "string",
-            "title": "Token",
-            "description": "Twilio Token"
-          }
+          "sid": { "type": "string", "title": "Sid", "description": "Twilio Account SID" },
+          "token": { "type": "string", "title": "Token", "description": "Twilio Token" }
         },
         "type": "object",
         "required": ["phone_number", "provider", "label", "sid", "token"],
@@ -8596,17 +8428,9 @@
       },
       "CustomLLM": {
         "properties": {
-          "url": {
-            "type": "string",
-            "title": "Url"
-          },
-          "model_id": {
-            "type": "string",
-            "title": "Model Id"
-          },
-          "api_key": {
-            "$ref": "#/components/schemas/ConvAISecretLocator"
-          }
+          "url": { "type": "string", "title": "Url" },
+          "model_id": { "type": "string", "title": "Model Id" },
+          "api_key": { "$ref": "#/components/schemas/ConvAISecretLocator" }
         },
         "type": "object",
         "required": ["url"],
@@ -8614,20 +8438,10 @@
       },
       "DataCollectionResultCommonModel": {
         "properties": {
-          "data_collection_id": {
-            "type": "string",
-            "title": "Data Collection Id"
-          },
-          "value": {
-            "title": "Value"
-          },
-          "json_schema": {
-            "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          }
+          "data_collection_id": { "type": "string", "title": "Data Collection Id" },
+          "value": { "title": "Value" },
+          "json_schema": { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
+          "rationale": { "type": "string", "title": "Rationale" }
         },
         "type": "object",
         "required": ["data_collection_id", "rationale"],
@@ -8635,44 +8449,34 @@
       },
       "DoDubbingResponseModel": {
         "properties": {
-          "dubbing_id": {
-            "type": "string",
-            "title": "Dubbing Id"
-          },
-          "expected_duration_sec": {
-            "type": "number",
-            "title": "Expected Duration Sec"
-          }
+          "dubbing_id": { "type": "string", "title": "Dubbing Id" },
+          "expected_duration_sec": { "type": "number", "title": "Expected Duration Sec" }
         },
         "type": "object",
         "required": ["dubbing_id", "expected_duration_sec"],
         "title": "DoDubbingResponseModel"
       },
+      "DubbingMediaMetadata": {
+        "properties": {
+          "content_type": { "type": "string", "title": "Content Type" },
+          "duration": { "type": "number", "title": "Duration" }
+        },
+        "type": "object",
+        "required": ["content_type", "duration"],
+        "title": "DubbingMediaMetadata"
+      },
       "DubbingMetadataResponse": {
         "properties": {
-          "dubbing_id": {
-            "type": "string",
-            "title": "Dubbing Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "dubbing_id": { "type": "string", "title": "Dubbing Id" },
+          "name": { "type": "string", "title": "Name" },
+          "status": { "type": "string", "title": "Status" },
           "target_languages": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Target Languages"
           },
-          "error": {
-            "type": "string",
-            "title": "Error"
-          }
+          "media_metadata": { "$ref": "#/components/schemas/DubbingMediaMetadata" },
+          "error": { "type": "string", "title": "Error" }
         },
         "type": "object",
         "required": ["dubbing_id", "name", "status", "target_languages"],
@@ -8683,18 +8487,10 @@
           "dynamic_variable_placeholders": {
             "additionalProperties": {
               "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "boolean"
-                }
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "integer" },
+                { "type": "boolean" }
               ]
             },
             "type": "object",
@@ -8704,12 +8500,16 @@
         "type": "object",
         "title": "DynamicVariablesConfig"
       },
-      "EditProjectResponseModel": {
+      "EditChapterResponseModel": {
         "properties": {
-          "project": {
-            "$ref": "#/components/schemas/ProjectResponseModel"
-          }
+          "chapter": { "$ref": "#/components/schemas/ChapterWithContentResponseModel" }
         },
+        "type": "object",
+        "required": ["chapter"],
+        "title": "EditChapterResponseModel"
+      },
+      "EditProjectResponseModel": {
+        "properties": { "project": { "$ref": "#/components/schemas/ProjectResponseModel" } },
         "type": "object",
         "required": ["project"],
         "title": "EditProjectResponseModel"
@@ -8723,9 +8523,7 @@
       "EvaluationSettings": {
         "properties": {
           "criteria": {
-            "items": {
-              "$ref": "#/components/schemas/PromptEvaluationCriteria"
-            },
+            "items": { "$ref": "#/components/schemas/PromptEvaluationCriteria" },
             "type": "array",
             "title": "Criteria"
           }
@@ -8742,18 +8540,9 @@
       },
       "ExtendedSubscriptionResponseModel": {
         "properties": {
-          "tier": {
-            "type": "string",
-            "title": "Tier"
-          },
-          "character_count": {
-            "type": "integer",
-            "title": "Character Count"
-          },
-          "character_limit": {
-            "type": "integer",
-            "title": "Character Limit"
-          },
+          "tier": { "type": "string", "title": "Tier" },
+          "character_count": { "type": "integer", "title": "Character Count" },
+          "character_limit": { "type": "integer", "title": "Character Limit" },
           "can_extend_character_limit": {
             "type": "boolean",
             "title": "Can Extend Character Limit"
@@ -8766,30 +8555,12 @@
             "type": "integer",
             "title": "Next Character Count Reset Unix"
           },
-          "voice_slots_used": {
-            "type": "integer",
-            "title": "Voice Slots Used"
-          },
-          "voice_limit": {
-            "type": "integer",
-            "title": "Voice Limit"
-          },
-          "max_voice_add_edits": {
-            "type": "integer",
-            "title": "Max Voice Add Edits"
-          },
-          "voice_add_edit_counter": {
-            "type": "integer",
-            "title": "Voice Add Edit Counter"
-          },
-          "professional_voice_limit": {
-            "type": "integer",
-            "title": "Professional Voice Limit"
-          },
-          "can_extend_voice_limit": {
-            "type": "boolean",
-            "title": "Can Extend Voice Limit"
-          },
+          "voice_slots_used": { "type": "integer", "title": "Voice Slots Used" },
+          "voice_limit": { "type": "integer", "title": "Voice Limit" },
+          "max_voice_add_edits": { "type": "integer", "title": "Max Voice Add Edits" },
+          "voice_add_edit_counter": { "type": "integer", "title": "Voice Add Edit Counter" },
+          "professional_voice_limit": { "type": "integer", "title": "Professional Voice Limit" },
+          "can_extend_voice_limit": { "type": "boolean", "title": "Can Extend Voice Limit" },
           "can_use_instant_voice_cloning": {
             "type": "boolean",
             "title": "Can Use Instant Voice Cloning"
@@ -8798,11 +8569,7 @@
             "type": "boolean",
             "title": "Can Use Professional Voice Cloning"
           },
-          "currency": {
-            "type": "string",
-            "enum": ["usd", "eur"],
-            "title": "Currency"
-          },
+          "currency": { "type": "string", "enum": ["usd", "eur"], "title": "Currency" },
           "status": {
             "type": "string",
             "enum": [
@@ -8827,13 +8594,8 @@
             "enum": ["monthly_period", "annual_period"],
             "title": "Character Refresh Period"
           },
-          "next_invoice": {
-            "$ref": "#/components/schemas/InvoiceResponseModel"
-          },
-          "has_open_invoices": {
-            "type": "boolean",
-            "title": "Has Open Invoices"
-          }
+          "next_invoice": { "$ref": "#/components/schemas/InvoiceResponseModel" },
+          "has_open_invoices": { "type": "boolean", "title": "Has Open Invoices" }
         },
         "type": "object",
         "required": [
@@ -8862,39 +8624,14 @@
       },
       "FeedbackResponseModel": {
         "properties": {
-          "thumbs_up": {
-            "type": "boolean",
-            "title": "Thumbs Up"
-          },
-          "feedback": {
-            "type": "string",
-            "title": "Feedback"
-          },
-          "emotions": {
-            "type": "boolean",
-            "title": "Emotions"
-          },
-          "inaccurate_clone": {
-            "type": "boolean",
-            "title": "Inaccurate Clone"
-          },
-          "glitches": {
-            "type": "boolean",
-            "title": "Glitches"
-          },
-          "audio_quality": {
-            "type": "boolean",
-            "title": "Audio Quality"
-          },
-          "other": {
-            "type": "boolean",
-            "title": "Other"
-          },
-          "review_status": {
-            "type": "string",
-            "title": "Review Status",
-            "default": "not_reviewed"
-          }
+          "thumbs_up": { "type": "boolean", "title": "Thumbs Up" },
+          "feedback": { "type": "string", "title": "Feedback" },
+          "emotions": { "type": "boolean", "title": "Emotions" },
+          "inaccurate_clone": { "type": "boolean", "title": "Inaccurate Clone" },
+          "glitches": { "type": "boolean", "title": "Glitches" },
+          "audio_quality": { "type": "boolean", "title": "Audio Quality" },
+          "other": { "type": "boolean", "title": "Other" },
+          "review_status": { "type": "string", "title": "Review Status", "default": "not_reviewed" }
         },
         "type": "object",
         "required": [
@@ -8910,10 +8647,7 @@
       },
       "FineTuningResponseModel": {
         "properties": {
-          "is_allowed_to_fine_tune": {
-            "type": "boolean",
-            "title": "Is Allowed To Fine Tune"
-          },
+          "is_allowed_to_fine_tune": { "type": "boolean", "title": "Is Allowed To Fine Tune" },
           "state": {
             "additionalProperties": {
               "type": "string",
@@ -8923,9 +8657,7 @@
             "title": "State"
           },
           "verification_failures": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Verification Failures"
           },
@@ -8937,49 +8669,26 @@
             "type": "boolean",
             "title": "Manual Verification Requested"
           },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
+          "language": { "type": "string", "title": "Language" },
           "progress": {
-            "additionalProperties": {
-              "type": "number"
-            },
+            "additionalProperties": { "type": "number" },
             "type": "object",
             "title": "Progress"
           },
           "message": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Message"
           },
-          "dataset_duration_seconds": {
-            "type": "number",
-            "title": "Dataset Duration Seconds"
-          },
+          "dataset_duration_seconds": { "type": "number", "title": "Dataset Duration Seconds" },
           "verification_attempts": {
-            "items": {
-              "$ref": "#/components/schemas/VerificationAttemptResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VerificationAttemptResponseModel" },
             "type": "array",
             "title": "Verification Attempts"
           },
-          "slice_ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Slice Ids"
-          },
-          "manual_verification": {
-            "$ref": "#/components/schemas/ManualVerificationResponseModel"
-          },
-          "max_verification_attempts": {
-            "type": "integer",
-            "title": "Max Verification Attempts"
-          },
+          "slice_ids": { "items": { "type": "string" }, "type": "array", "title": "Slice Ids" },
+          "manual_verification": { "$ref": "#/components/schemas/ManualVerificationResponseModel" },
+          "max_verification_attempts": { "type": "integer", "title": "Max Verification Attempts" },
           "next_max_verification_attempts_reset_unix_ms": {
             "type": "integer",
             "title": "Next Max Verification Attempts Reset Unix Ms"
@@ -8997,13 +8706,8 @@
       },
       "GetAgentEmbedResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "widget_config": {
-            "$ref": "#/components/schemas/WidgetConfigResponseModel"
-          }
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "widget_config": { "$ref": "#/components/schemas/WidgetConfigResponseModel" }
         },
         "type": "object",
         "required": ["agent_id", "widget_config"],
@@ -9011,13 +8715,8 @@
       },
       "GetAgentLinkResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "token": {
-            "$ref": "#/components/schemas/ConversationTokenDBModel"
-          }
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "token": { "$ref": "#/components/schemas/ConversationTokenDBModel" }
         },
         "type": "object",
         "required": ["agent_id"],
@@ -9025,27 +8724,13 @@
       },
       "GetAgentResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "conversation_config": {
-            "$ref": "#/components/schemas/ConversationalConfig"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/AgentMetadataResponseModel"
-          },
-          "platform_settings": {
-            "$ref": "#/components/schemas/AgentPlatformSettings"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "name": { "type": "string", "title": "Name" },
+          "conversation_config": { "$ref": "#/components/schemas/ConversationalConfig" },
+          "metadata": { "$ref": "#/components/schemas/AgentMetadataResponseModel" },
+          "platform_settings": { "$ref": "#/components/schemas/AgentPlatformSettings" },
           "secrets": {
-            "items": {
-              "$ref": "#/components/schemas/ConvAIStoredSecretConfig"
-            },
+            "items": { "$ref": "#/components/schemas/ConvAIStoredSecretConfig" },
             "type": "array",
             "title": "Secrets"
           }
@@ -9057,20 +8742,12 @@
       "GetAgentsPageResponseModel": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/AgentSummaryResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/AgentSummaryResponseModel" },
             "type": "array",
             "title": "Agents"
           },
-          "next_cursor": {
-            "type": "string",
-            "title": "Next Cursor"
-          },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More"
-          }
+          "next_cursor": { "type": "string", "title": "Next Cursor" },
+          "has_more": { "type": "boolean", "title": "Has More" }
         },
         "type": "object",
         "required": ["agents", "has_more"],
@@ -9079,9 +8756,7 @@
       "GetChaptersResponseModel": {
         "properties": {
           "chapters": {
-            "items": {
-              "$ref": "#/components/schemas/ChapterResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ChapterResponseModel" },
             "type": "array",
             "title": "Chapters"
           }
@@ -9092,32 +8767,16 @@
       },
       "GetConversationResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "conversation_id": {
-            "type": "string",
-            "title": "Conversation Id"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["processing", "done"],
-            "title": "Status"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "conversation_id": { "type": "string", "title": "Conversation Id" },
+          "status": { "type": "string", "enum": ["processing", "done"], "title": "Status" },
           "transcript": {
-            "items": {
-              "$ref": "#/components/schemas/ConversationHistoryTranscriptCommonModel"
-            },
+            "items": { "$ref": "#/components/schemas/ConversationHistoryTranscriptCommonModel" },
             "type": "array",
             "title": "Transcript"
           },
-          "metadata": {
-            "$ref": "#/components/schemas/ConversationHistoryMetadataCommonModel"
-          },
-          "analysis": {
-            "$ref": "#/components/schemas/ConversationHistoryAnalysisCommonModel"
-          },
+          "metadata": { "$ref": "#/components/schemas/ConversationHistoryMetadataCommonModel" },
+          "analysis": { "$ref": "#/components/schemas/ConversationHistoryAnalysisCommonModel" },
           "conversation_initiation_client_data": {
             "$ref": "#/components/schemas/ConversationInitiationClientData"
           }
@@ -9129,20 +8788,12 @@
       "GetConversationsPageResponseModel": {
         "properties": {
           "conversations": {
-            "items": {
-              "$ref": "#/components/schemas/ConversationSummaryResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ConversationSummaryResponseModel" },
             "type": "array",
             "title": "Conversations"
           },
-          "next_cursor": {
-            "type": "string",
-            "title": "Next Cursor"
-          },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More"
-          }
+          "next_cursor": { "type": "string", "title": "Next Cursor" },
+          "has_more": { "type": "boolean", "title": "Has More" }
         },
         "type": "object",
         "required": ["conversations", "has_more"],
@@ -9150,19 +8801,9 @@
       },
       "GetKnowledgeBaseReponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["file", "url"],
-            "title": "Type"
-          },
-          "extracted_inner_html": {
-            "type": "string",
-            "title": "Extracted Inner Html"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "type": { "type": "string", "enum": ["file", "url"], "title": "Type" },
+          "extracted_inner_html": { "type": "string", "title": "Extracted Inner Html" }
         },
         "type": "object",
         "required": ["id", "type", "extracted_inner_html"],
@@ -9171,20 +8812,12 @@
       "GetLibraryVoicesResponseModel": {
         "properties": {
           "voices": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryVoiceResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryVoiceResponseModel" },
             "type": "array",
             "title": "Voices"
           },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More"
-          },
-          "last_sort_id": {
-            "type": "string",
-            "title": "Last Sort Id"
-          }
+          "has_more": { "type": "boolean", "title": "Has More" },
+          "last_sort_id": { "type": "string", "title": "Last Sort Id" }
         },
         "type": "object",
         "required": ["voices", "has_more"],
@@ -9198,11 +8831,7 @@
             "description": "Phone number"
           },
           "provider": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TelephonyProvider"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/TelephonyProvider" }],
             "description": "Phone provider"
           },
           "label": {
@@ -9210,13 +8839,8 @@
             "title": "Label",
             "description": "Label for the phone number"
           },
-          "phone_number_id": {
-            "type": "string",
-            "title": "Phone Number Id"
-          },
-          "assigned_agent": {
-            "$ref": "#/components/schemas/PhoneNumberAgentInfo"
-          }
+          "phone_number_id": { "type": "string", "title": "Phone Number Id" },
+          "assigned_agent": { "$ref": "#/components/schemas/PhoneNumberAgentInfo" }
         },
         "type": "object",
         "required": ["phone_number", "provider", "label", "phone_number_id"],
@@ -9225,9 +8849,7 @@
       "GetProjectsResponseModel": {
         "properties": {
           "projects": {
-            "items": {
-              "$ref": "#/components/schemas/ProjectResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ProjectResponseModel" },
             "type": "array",
             "title": "Projects"
           }
@@ -9245,14 +8867,8 @@
             "type": "array",
             "title": "Pronunciation Dictionaries"
           },
-          "next_cursor": {
-            "type": "string",
-            "title": "Next Cursor"
-          },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More"
-          }
+          "next_cursor": { "type": "string", "title": "Next Cursor" },
+          "has_more": { "type": "boolean", "title": "Has More" }
         },
         "type": "object",
         "required": ["pronunciation_dictionaries", "next_cursor", "has_more"],
@@ -9260,30 +8876,12 @@
       },
       "GetPronunciationDictionaryMetadataResponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "latest_version_id": {
-            "type": "string",
-            "title": "Latest Version Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "created_by": {
-            "type": "string",
-            "title": "Created By"
-          },
-          "creation_time_unix": {
-            "type": "integer",
-            "title": "Creation Time Unix"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "latest_version_id": { "type": "string", "title": "Latest Version Id" },
+          "name": { "type": "string", "title": "Name" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "creation_time_unix": { "type": "integer", "title": "Creation Time Unix" },
+          "description": { "type": "string", "title": "Description" }
         },
         "type": "object",
         "required": ["id", "latest_version_id", "name", "created_by", "creation_time_unix"],
@@ -9292,20 +8890,12 @@
       "GetSpeechHistoryResponseModel": {
         "properties": {
           "history": {
-            "items": {
-              "$ref": "#/components/schemas/SpeechHistoryItemResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/SpeechHistoryItemResponseModel" },
             "type": "array",
             "title": "History"
           },
-          "last_history_item_id": {
-            "type": "string",
-            "title": "Last History Item Id"
-          },
-          "has_more": {
-            "type": "boolean",
-            "title": "Has More"
-          }
+          "last_history_item_id": { "type": "string", "title": "Last History Item Id" },
+          "has_more": { "type": "boolean", "title": "Has More" }
         },
         "type": "object",
         "required": ["history", "last_history_item_id", "has_more"],
@@ -9314,9 +8904,7 @@
       "GetVoicesResponseModel": {
         "properties": {
           "voices": {
-            "items": {
-              "$ref": "#/components/schemas/VoiceResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VoiceResponseModel" },
             "type": "array",
             "title": "Voices"
           }
@@ -9328,9 +8916,7 @@
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
+            "items": { "$ref": "#/components/schemas/ValidationError" },
             "type": "array",
             "title": "Detail"
           }
@@ -9340,24 +8926,14 @@
       },
       "HistoryAlignmentResponseModel": {
         "properties": {
-          "characters": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Characters"
-          },
+          "characters": { "items": { "type": "string" }, "type": "array", "title": "Characters" },
           "character_start_times_seconds": {
-            "items": {
-              "type": "number"
-            },
+            "items": { "type": "number" },
             "type": "array",
             "title": "Character Start Times Seconds"
           },
           "character_end_times_seconds": {
-            "items": {
-              "type": "number"
-            },
+            "items": { "type": "number" },
             "type": "array",
             "title": "Character End Times Seconds"
           }
@@ -9368,12 +8944,8 @@
       },
       "HistoryAlignmentsResponseModel": {
         "properties": {
-          "alignment": {
-            "$ref": "#/components/schemas/HistoryAlignmentResponseModel"
-          },
-          "normalized_alignment": {
-            "$ref": "#/components/schemas/HistoryAlignmentResponseModel"
-          }
+          "alignment": { "$ref": "#/components/schemas/HistoryAlignmentResponseModel" },
+          "normalized_alignment": { "$ref": "#/components/schemas/HistoryAlignmentResponseModel" }
         },
         "type": "object",
         "required": ["alignment", "normalized_alignment"],
@@ -9381,31 +8953,16 @@
       },
       "ImageAvatar": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["image"],
-            "title": "Type",
-            "default": "image"
-          },
-          "url": {
-            "type": "string",
-            "title": "Url",
-            "default": ""
-          }
+          "type": { "type": "string", "enum": ["image"], "title": "Type", "default": "image" },
+          "url": { "type": "string", "title": "Url", "default": "" }
         },
         "type": "object",
         "title": "ImageAvatar"
       },
       "InvoiceResponseModel": {
         "properties": {
-          "amount_due_cents": {
-            "type": "integer",
-            "title": "Amount Due Cents"
-          },
-          "next_payment_attempt_unix": {
-            "type": "integer",
-            "title": "Next Payment Attempt Unix"
-          }
+          "amount_due_cents": { "type": "integer", "title": "Amount Due Cents" },
+          "next_payment_attempt_unix": { "type": "integer", "title": "Next Payment Attempt Unix" }
         },
         "type": "object",
         "required": ["amount_due_cents", "next_payment_attempt_unix"],
@@ -9413,19 +8970,9 @@
       },
       "KnowledgeBaseLocator": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["file", "url"],
-            "title": "Type"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          }
+          "type": { "type": "string", "enum": ["file", "url"], "title": "Type" },
+          "name": { "type": "string", "title": "Name" },
+          "id": { "type": "string", "title": "Id" }
         },
         "type": "object",
         "required": ["type", "name", "id"],
@@ -9441,6 +8988,7 @@
           "gpt-3.5-turbo",
           "gemini-1.5-pro",
           "gemini-1.5-flash",
+          "gemini-2.0-flash-exp",
           "gemini-1.0-pro",
           "claude-3-5-sonnet",
           "claude-3-haiku",
@@ -9452,12 +9000,8 @@
       },
       "LanguagePreset": {
         "properties": {
-          "overrides": {
-            "$ref": "#/components/schemas/ConversationConfigClientOverride"
-          },
-          "first_message_translation": {
-            "$ref": "#/components/schemas/LanguagePresetTranslation"
-          }
+          "overrides": { "$ref": "#/components/schemas/ConversationConfigClientOverride" },
+          "first_message_translation": { "$ref": "#/components/schemas/LanguagePresetTranslation" }
         },
         "type": "object",
         "required": ["overrides"],
@@ -9465,14 +9009,8 @@
       },
       "LanguagePresetTranslation": {
         "properties": {
-          "source_hash": {
-            "type": "string",
-            "title": "Source Hash"
-          },
-          "text": {
-            "type": "string",
-            "title": "Text"
-          }
+          "source_hash": { "type": "string", "title": "Source Hash" },
+          "text": { "type": "string", "title": "Text" }
         },
         "type": "object",
         "required": ["source_hash", "text"],
@@ -9480,14 +9018,8 @@
       },
       "LanguageResponseModel": {
         "properties": {
-          "language_id": {
-            "type": "string",
-            "title": "Language Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          }
+          "language_id": { "type": "string", "title": "Language Id" },
+          "name": { "type": "string", "title": "Name" }
         },
         "type": "object",
         "required": ["language_id", "name"],
@@ -9495,115 +9027,40 @@
       },
       "LibraryVoiceResponseModel": {
         "properties": {
-          "public_owner_id": {
-            "type": "string",
-            "title": "Public Owner Id"
-          },
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          },
-          "date_unix": {
-            "type": "integer",
-            "title": "Date Unix"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "accent": {
-            "type": "string",
-            "title": "Accent"
-          },
-          "gender": {
-            "type": "string",
-            "title": "Gender"
-          },
-          "age": {
-            "type": "string",
-            "title": "Age"
-          },
-          "descriptive": {
-            "type": "string",
-            "title": "Descriptive"
-          },
-          "use_case": {
-            "type": "string",
-            "title": "Use Case"
-          },
+          "public_owner_id": { "type": "string", "title": "Public Owner Id" },
+          "voice_id": { "type": "string", "title": "Voice Id" },
+          "date_unix": { "type": "integer", "title": "Date Unix" },
+          "name": { "type": "string", "title": "Name" },
+          "accent": { "type": "string", "title": "Accent" },
+          "gender": { "type": "string", "title": "Gender" },
+          "age": { "type": "string", "title": "Age" },
+          "descriptive": { "type": "string", "title": "Descriptive" },
+          "use_case": { "type": "string", "title": "Use Case" },
           "category": {
             "type": "string",
             "enum": ["generated", "cloned", "premade", "professional", "famous", "high_quality"],
             "title": "Category"
           },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "preview_url": {
-            "type": "string",
-            "title": "Preview Url"
-          },
-          "usage_character_count_1y": {
-            "type": "integer",
-            "title": "Usage Character Count 1Y"
-          },
-          "usage_character_count_7d": {
-            "type": "integer",
-            "title": "Usage Character Count 7D"
-          },
+          "language": { "type": "string", "title": "Language" },
+          "description": { "type": "string", "title": "Description" },
+          "preview_url": { "type": "string", "title": "Preview Url" },
+          "usage_character_count_1y": { "type": "integer", "title": "Usage Character Count 1Y" },
+          "usage_character_count_7d": { "type": "integer", "title": "Usage Character Count 7D" },
           "play_api_usage_character_count_1y": {
             "type": "integer",
             "title": "Play Api Usage Character Count 1Y"
           },
-          "cloned_by_count": {
-            "type": "integer",
-            "title": "Cloned By Count"
-          },
-          "rate": {
-            "type": "number",
-            "title": "Rate"
-          },
-          "free_users_allowed": {
-            "type": "boolean",
-            "title": "Free Users Allowed"
-          },
-          "live_moderation_enabled": {
-            "type": "boolean",
-            "title": "Live Moderation Enabled"
-          },
-          "featured": {
-            "type": "boolean",
-            "title": "Featured"
-          },
-          "notice_period": {
-            "type": "integer",
-            "title": "Notice Period"
-          },
-          "instagram_username": {
-            "type": "string",
-            "title": "Instagram Username"
-          },
-          "twitter_username": {
-            "type": "string",
-            "title": "Twitter Username"
-          },
-          "youtube_username": {
-            "type": "string",
-            "title": "Youtube Username"
-          },
-          "tiktok_username": {
-            "type": "string",
-            "title": "Tiktok Username"
-          },
-          "image_url": {
-            "type": "string",
-            "title": "Image Url"
-          }
+          "cloned_by_count": { "type": "integer", "title": "Cloned By Count" },
+          "rate": { "type": "number", "title": "Rate" },
+          "free_users_allowed": { "type": "boolean", "title": "Free Users Allowed" },
+          "live_moderation_enabled": { "type": "boolean", "title": "Live Moderation Enabled" },
+          "featured": { "type": "boolean", "title": "Featured" },
+          "notice_period": { "type": "integer", "title": "Notice Period" },
+          "instagram_username": { "type": "string", "title": "Instagram Username" },
+          "twitter_username": { "type": "string", "title": "Twitter Username" },
+          "youtube_username": { "type": "string", "title": "Youtube Username" },
+          "tiktok_username": { "type": "string", "title": "Tiktok Username" },
+          "image_url": { "type": "string", "title": "Image Url" }
         },
         "type": "object",
         "required": [
@@ -9638,16 +9095,8 @@
             "enum": ["boolean", "string", "integer", "number"],
             "title": "Type"
           },
-          "description": {
-            "type": "string",
-            "title": "Description",
-            "default": ""
-          },
-          "dynamic_variable": {
-            "type": "string",
-            "title": "Dynamic Variable",
-            "default": ""
-          }
+          "description": { "type": "string", "title": "Description", "default": "" },
+          "dynamic_variable": { "type": "string", "title": "Dynamic Variable", "default": "" }
         },
         "type": "object",
         "required": ["type"],
@@ -9655,26 +9104,11 @@
       },
       "ManualVerificationFileResponseModel": {
         "properties": {
-          "file_id": {
-            "type": "string",
-            "title": "File Id"
-          },
-          "file_name": {
-            "type": "string",
-            "title": "File Name"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          },
-          "upload_date_unix": {
-            "type": "integer",
-            "title": "Upload Date Unix"
-          }
+          "file_id": { "type": "string", "title": "File Id" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" },
+          "upload_date_unix": { "type": "integer", "title": "Upload Date Unix" }
         },
         "type": "object",
         "required": ["file_id", "file_name", "mime_type", "size_bytes", "upload_date_unix"],
@@ -9682,18 +9116,10 @@
       },
       "ManualVerificationResponseModel": {
         "properties": {
-          "extra_text": {
-            "type": "string",
-            "title": "Extra Text"
-          },
-          "request_time_unix": {
-            "type": "integer",
-            "title": "Request Time Unix"
-          },
+          "extra_text": { "type": "string", "title": "Extra Text" },
+          "request_time_unix": { "type": "integer", "title": "Request Time Unix" },
           "files": {
-            "items": {
-              "$ref": "#/components/schemas/ManualVerificationFileResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ManualVerificationFileResponseModel" },
             "type": "array",
             "title": "Files"
           }
@@ -9704,10 +9130,7 @@
       },
       "ModelRatesResponseModel": {
         "properties": {
-          "character_cost_multiplier": {
-            "type": "number",
-            "title": "Character Cost Multiplier"
-          }
+          "character_cost_multiplier": { "type": "number", "title": "Character Cost Multiplier" }
         },
         "type": "object",
         "required": ["character_cost_multiplier"],
@@ -9715,50 +9138,17 @@
       },
       "ModelResponseModel": {
         "properties": {
-          "model_id": {
-            "type": "string",
-            "title": "Model Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "can_be_finetuned": {
-            "type": "boolean",
-            "title": "Can Be Finetuned"
-          },
-          "can_do_text_to_speech": {
-            "type": "boolean",
-            "title": "Can Do Text To Speech"
-          },
-          "can_do_voice_conversion": {
-            "type": "boolean",
-            "title": "Can Do Voice Conversion"
-          },
-          "can_use_style": {
-            "type": "boolean",
-            "title": "Can Use Style"
-          },
-          "can_use_speaker_boost": {
-            "type": "boolean",
-            "title": "Can Use Speaker Boost"
-          },
-          "serves_pro_voices": {
-            "type": "boolean",
-            "title": "Serves Pro Voices"
-          },
-          "token_cost_factor": {
-            "type": "number",
-            "title": "Token Cost Factor"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "requires_alpha_access": {
-            "type": "boolean",
-            "title": "Requires Alpha Access"
-          },
+          "model_id": { "type": "string", "title": "Model Id" },
+          "name": { "type": "string", "title": "Name" },
+          "can_be_finetuned": { "type": "boolean", "title": "Can Be Finetuned" },
+          "can_do_text_to_speech": { "type": "boolean", "title": "Can Do Text To Speech" },
+          "can_do_voice_conversion": { "type": "boolean", "title": "Can Do Voice Conversion" },
+          "can_use_style": { "type": "boolean", "title": "Can Use Style" },
+          "can_use_speaker_boost": { "type": "boolean", "title": "Can Use Speaker Boost" },
+          "serves_pro_voices": { "type": "boolean", "title": "Serves Pro Voices" },
+          "token_cost_factor": { "type": "number", "title": "Token Cost Factor" },
+          "description": { "type": "string", "title": "Description" },
+          "requires_alpha_access": { "type": "boolean", "title": "Requires Alpha Access" },
           "max_characters_request_free_user": {
             "type": "integer",
             "title": "Max Characters Request Free User"
@@ -9772,15 +9162,11 @@
             "title": "Maximum Text Length Per Request"
           },
           "languages": {
-            "items": {
-              "$ref": "#/components/schemas/LanguageResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/LanguageResponseModel" },
             "type": "array",
             "title": "Languages"
           },
-          "model_rates": {
-            "$ref": "#/components/schemas/ModelRatesResponseModel"
-          },
+          "model_rates": { "$ref": "#/components/schemas/ModelRatesResponseModel" },
           "concurrency_group": {
             "type": "string",
             "enum": ["standard", "turbo"],
@@ -9811,10 +9197,7 @@
       },
       "ModerationStatusResponseModel": {
         "properties": {
-          "is_in_probation": {
-            "type": "boolean",
-            "title": "Is In Probation"
-          },
+          "is_in_probation": { "type": "boolean", "title": "Is In Probation" },
           "enterprise_check_nogo_voice": {
             "type": "boolean",
             "title": "Enterprise Check Nogo Voice"
@@ -9823,10 +9206,7 @@
             "type": "boolean",
             "title": "Enterprise Check Block Nogo Voice"
           },
-          "never_live_moderate": {
-            "type": "boolean",
-            "title": "Never Live Moderate"
-          },
+          "never_live_moderate": { "type": "boolean", "title": "Never Live Moderate" },
           "nogo_voice_similar_voice_upload_count": {
             "type": "integer",
             "title": "Nogo Voice Similar Voice Upload Count"
@@ -9845,10 +9225,7 @@
             "enum": ["warning", "warning_cleared"],
             "title": "Warning Status"
           },
-          "on_watchlist": {
-            "type": "boolean",
-            "title": "On Watchlist"
-          }
+          "on_watchlist": { "type": "boolean", "title": "On Watchlist" }
         },
         "type": "object",
         "required": [
@@ -9866,41 +9243,20 @@
       },
       "ObjectJsonSchemaProperty": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["object"],
-            "title": "Type",
-            "default": "object"
-          },
+          "type": { "type": "string", "enum": ["object"], "title": "Type", "default": "object" },
           "properties": {
             "additionalProperties": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/ObjectJsonSchemaProperty"
-                },
-                {
-                  "$ref": "#/components/schemas/ArrayJsonSchemaProperty"
-                }
+                { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
+                { "$ref": "#/components/schemas/ObjectJsonSchemaProperty" },
+                { "$ref": "#/components/schemas/ArrayJsonSchemaProperty" }
               ]
             },
             "type": "object",
             "title": "Properties"
           },
-          "required": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Required"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description",
-            "default": ""
-          }
+          "required": { "items": { "type": "string" }, "type": "array", "title": "Required" },
+          "description": { "type": "string", "title": "Description", "default": "" }
         },
         "additionalProperties": false,
         "type": "object",
@@ -9908,51 +9264,83 @@
       },
       "OrbAvatar": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["orb"],
-            "title": "Type",
-            "default": "orb"
-          },
-          "color_1": {
-            "type": "string",
-            "title": "Color 1",
-            "default": "#2792dc"
-          },
-          "color_2": {
-            "type": "string",
-            "title": "Color 2",
-            "default": "#9ce6e6"
-          }
+          "type": { "type": "string", "enum": ["orb"], "title": "Type", "default": "orb" },
+          "color_1": { "type": "string", "title": "Color 1", "default": "#2792dc" },
+          "color_2": { "type": "string", "title": "Color 2", "default": "#9ce6e6" }
         },
         "type": "object",
         "title": "OrbAvatar"
       },
       "PhoneNumberAgentInfo": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          }
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" }
         },
         "type": "object",
         "required": ["agent_id", "agent_name"],
         "title": "PhoneNumberAgentInfo"
       },
+      "PodcastBulletinMode": {
+        "properties": {
+          "type": { "type": "string", "enum": ["bulletin"], "title": "Type" },
+          "bulletin": { "$ref": "#/components/schemas/PodcastBulletinModeData" }
+        },
+        "type": "object",
+        "required": ["type", "bulletin"],
+        "title": "PodcastBulletinMode"
+      },
+      "PodcastBulletinModeData": {
+        "properties": { "host_voice_id": { "type": "string", "title": "Host Voice Id" } },
+        "type": "object",
+        "required": ["host_voice_id"],
+        "title": "PodcastBulletinModeData"
+      },
+      "PodcastConversationMode": {
+        "properties": {
+          "type": { "type": "string", "enum": ["conversation"], "title": "Type" },
+          "conversation": { "$ref": "#/components/schemas/PodcastConversationModeData" }
+        },
+        "type": "object",
+        "required": ["type", "conversation"],
+        "title": "PodcastConversationMode"
+      },
+      "PodcastConversationModeData": {
+        "properties": {
+          "host_voice_id": { "type": "string", "title": "Host Voice Id" },
+          "guest_voice_id": { "type": "string", "title": "Guest Voice Id" }
+        },
+        "type": "object",
+        "required": ["host_voice_id", "guest_voice_id"],
+        "title": "PodcastConversationModeData"
+      },
+      "PodcastProjectResponseModel": {
+        "properties": { "project": { "$ref": "#/components/schemas/ProjectResponseModel" } },
+        "type": "object",
+        "required": ["project"],
+        "title": "PodcastProjectResponseModel"
+      },
+      "PodcastTextSource": {
+        "properties": {
+          "type": { "type": "string", "enum": ["text"], "title": "Type" },
+          "text": { "type": "string", "title": "Text" }
+        },
+        "type": "object",
+        "required": ["type", "text"],
+        "title": "PodcastTextSource"
+      },
+      "PodcastURLSource": {
+        "properties": {
+          "type": { "type": "string", "enum": ["url"], "title": "Type" },
+          "url": { "type": "string", "title": "Url" }
+        },
+        "type": "object",
+        "required": ["type", "url"],
+        "title": "PodcastURLSource"
+      },
       "PostAgentAvatarResponseModel": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "avatar_url": {
-            "type": "string",
-            "title": "Avatar Url"
-          }
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "avatar_url": { "type": "string", "title": "Avatar Url" }
         },
         "type": "object",
         "required": ["agent_id"],
@@ -9960,10 +9348,18 @@
       },
       "PrivacyConfig": {
         "properties": {
-          "record_voice": {
+          "record_voice": { "type": "boolean", "title": "Record Voice", "default": true },
+          "retention_days": { "type": "integer", "title": "Retention Days", "default": -1 },
+          "delete_transcript_and_pii": {
             "type": "boolean",
-            "title": "Record Voice",
-            "default": true
+            "title": "Delete Transcript And Pii",
+            "default": false
+          },
+          "delete_audio": { "type": "boolean", "title": "Delete Audio", "default": false },
+          "apply_to_existing_conversations": {
+            "type": "boolean",
+            "title": "Apply To Existing Conversations",
+            "default": false
           }
         },
         "type": "object",
@@ -9971,26 +9367,11 @@
       },
       "ProfilePageResponseModel": {
         "properties": {
-          "handle": {
-            "type": "string",
-            "title": "Handle"
-          },
-          "public_user_id": {
-            "type": "string",
-            "title": "Public User Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "bio": {
-            "type": "string",
-            "title": "Bio"
-          },
-          "profile_picture": {
-            "type": "string",
-            "title": "Profile Picture"
-          }
+          "handle": { "type": "string", "title": "Handle" },
+          "public_user_id": { "type": "string", "title": "Public User Id" },
+          "name": { "type": "string", "title": "Name" },
+          "bio": { "type": "string", "title": "Bio" },
+          "profile_picture": { "type": "string", "title": "Profile Picture" }
         },
         "type": "object",
         "required": ["handle", "public_user_id", "name", "bio", "profile_picture"],
@@ -9998,10 +9379,7 @@
       },
       "ProjectCreationMetaResponseModel": {
         "properties": {
-          "creation_progress": {
-            "type": "number",
-            "title": "Creation Progress"
-          },
+          "creation_progress": { "type": "number", "title": "Creation Progress" },
           "status": {
             "type": "string",
             "enum": ["pending", "creating", "finished", "failed"],
@@ -10019,90 +9397,30 @@
       },
       "ProjectExtendedResponseModel": {
         "properties": {
-          "project_id": {
-            "type": "string",
-            "title": "Project Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "create_date_unix": {
-            "type": "integer",
-            "title": "Create Date Unix"
-          },
-          "default_title_voice_id": {
-            "type": "string",
-            "title": "Default Title Voice Id"
-          },
-          "default_paragraph_voice_id": {
-            "type": "string",
-            "title": "Default Paragraph Voice Id"
-          },
-          "default_model_id": {
-            "type": "string",
-            "title": "Default Model Id"
-          },
-          "last_conversion_date_unix": {
-            "type": "integer",
-            "title": "Last Conversion Date Unix"
-          },
-          "can_be_downloaded": {
-            "type": "boolean",
-            "title": "Can Be Downloaded"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "author": {
-            "type": "string",
-            "title": "Author"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "genres": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Genres"
-          },
-          "cover_image_url": {
-            "type": "string",
-            "title": "Cover Image Url"
-          },
+          "project_id": { "type": "string", "title": "Project Id" },
+          "name": { "type": "string", "title": "Name" },
+          "create_date_unix": { "type": "integer", "title": "Create Date Unix" },
+          "default_title_voice_id": { "type": "string", "title": "Default Title Voice Id" },
+          "default_paragraph_voice_id": { "type": "string", "title": "Default Paragraph Voice Id" },
+          "default_model_id": { "type": "string", "title": "Default Model Id" },
+          "last_conversion_date_unix": { "type": "integer", "title": "Last Conversion Date Unix" },
+          "can_be_downloaded": { "type": "boolean", "title": "Can Be Downloaded" },
+          "title": { "type": "string", "title": "Title" },
+          "author": { "type": "string", "title": "Author" },
+          "description": { "type": "string", "title": "Description" },
+          "genres": { "items": { "type": "string" }, "type": "array", "title": "Genres" },
+          "cover_image_url": { "type": "string", "title": "Cover Image Url" },
           "target_audience": {
             "type": "string",
             "enum": ["children", "young adult", "adult", "all ages"],
             "title": "Target Audience"
           },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "original_publication_date": {
-            "type": "string",
-            "title": "Original Publication Date"
-          },
-          "mature_content": {
-            "type": "boolean",
-            "title": "Mature Content"
-          },
-          "isbn_number": {
-            "type": "string",
-            "title": "Isbn Number"
-          },
-          "volume_normalization": {
-            "type": "boolean",
-            "title": "Volume Normalization"
-          },
+          "language": { "type": "string", "title": "Language" },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "original_publication_date": { "type": "string", "title": "Original Publication Date" },
+          "mature_content": { "type": "boolean", "title": "Mature Content" },
+          "isbn_number": { "type": "string", "title": "Isbn Number" },
+          "volume_normalization": { "type": "boolean", "title": "Volume Normalization" },
           "state": {
             "type": "string",
             "enum": ["creating", "default", "converting", "in_queue"],
@@ -10113,38 +9431,25 @@
             "enum": ["admin", "editor", "viewer"],
             "title": "Access Level"
           },
-          "fiction": {
-            "type": "string",
-            "enum": ["fiction", "non-fiction"],
-            "title": "Fiction"
-          },
-          "quality_check_on": {
-            "type": "boolean",
-            "title": "Quality Check On"
-          },
+          "fiction": { "type": "string", "enum": ["fiction", "non-fiction"], "title": "Fiction" },
+          "quality_check_on": { "type": "boolean", "title": "Quality Check On" },
           "quality_check_on_when_bulk_convert": {
             "type": "boolean",
             "title": "Quality Check On When Bulk Convert"
           },
-          "creation_meta": {
-            "$ref": "#/components/schemas/ProjectCreationMetaResponseModel"
-          },
+          "creation_meta": { "$ref": "#/components/schemas/ProjectCreationMetaResponseModel" },
           "quality_preset": {
             "type": "string",
             "enum": ["standard", "high", "highest", "ultra", "ultra_lossless"],
             "title": "Quality Preset"
           },
           "chapters": {
-            "items": {
-              "$ref": "#/components/schemas/ChapterResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ChapterResponseModel" },
             "type": "array",
             "title": "Chapters"
           },
           "pronunciation_dictionary_versions": {
-            "items": {
-              "$ref": "#/components/schemas/PronunciationDictionaryVersionResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/PronunciationDictionaryVersionResponseModel" },
             "type": "array",
             "title": "Pronunciation Dictionary Versions"
           },
@@ -10153,10 +9458,7 @@
             "enum": ["auto", "on", "off", "apply_english"],
             "title": "Apply Text Normalization"
           },
-          "experimental": {
-            "type": "object",
-            "title": "Experimental"
-          }
+          "experimental": { "type": "object", "title": "Experimental" }
         },
         "type": "object",
         "required": [
@@ -10182,90 +9484,30 @@
       },
       "ProjectResponseModel": {
         "properties": {
-          "project_id": {
-            "type": "string",
-            "title": "Project Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "create_date_unix": {
-            "type": "integer",
-            "title": "Create Date Unix"
-          },
-          "default_title_voice_id": {
-            "type": "string",
-            "title": "Default Title Voice Id"
-          },
-          "default_paragraph_voice_id": {
-            "type": "string",
-            "title": "Default Paragraph Voice Id"
-          },
-          "default_model_id": {
-            "type": "string",
-            "title": "Default Model Id"
-          },
-          "last_conversion_date_unix": {
-            "type": "integer",
-            "title": "Last Conversion Date Unix"
-          },
-          "can_be_downloaded": {
-            "type": "boolean",
-            "title": "Can Be Downloaded"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "author": {
-            "type": "string",
-            "title": "Author"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "genres": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Genres"
-          },
-          "cover_image_url": {
-            "type": "string",
-            "title": "Cover Image Url"
-          },
+          "project_id": { "type": "string", "title": "Project Id" },
+          "name": { "type": "string", "title": "Name" },
+          "create_date_unix": { "type": "integer", "title": "Create Date Unix" },
+          "default_title_voice_id": { "type": "string", "title": "Default Title Voice Id" },
+          "default_paragraph_voice_id": { "type": "string", "title": "Default Paragraph Voice Id" },
+          "default_model_id": { "type": "string", "title": "Default Model Id" },
+          "last_conversion_date_unix": { "type": "integer", "title": "Last Conversion Date Unix" },
+          "can_be_downloaded": { "type": "boolean", "title": "Can Be Downloaded" },
+          "title": { "type": "string", "title": "Title" },
+          "author": { "type": "string", "title": "Author" },
+          "description": { "type": "string", "title": "Description" },
+          "genres": { "items": { "type": "string" }, "type": "array", "title": "Genres" },
+          "cover_image_url": { "type": "string", "title": "Cover Image Url" },
           "target_audience": {
             "type": "string",
             "enum": ["children", "young adult", "adult", "all ages"],
             "title": "Target Audience"
           },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "original_publication_date": {
-            "type": "string",
-            "title": "Original Publication Date"
-          },
-          "mature_content": {
-            "type": "boolean",
-            "title": "Mature Content"
-          },
-          "isbn_number": {
-            "type": "string",
-            "title": "Isbn Number"
-          },
-          "volume_normalization": {
-            "type": "boolean",
-            "title": "Volume Normalization"
-          },
+          "language": { "type": "string", "title": "Language" },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "original_publication_date": { "type": "string", "title": "Original Publication Date" },
+          "mature_content": { "type": "boolean", "title": "Mature Content" },
+          "isbn_number": { "type": "string", "title": "Isbn Number" },
+          "volume_normalization": { "type": "boolean", "title": "Volume Normalization" },
           "state": {
             "type": "string",
             "enum": ["creating", "default", "converting", "in_queue"],
@@ -10276,22 +9518,13 @@
             "enum": ["admin", "editor", "viewer"],
             "title": "Access Level"
           },
-          "fiction": {
-            "type": "string",
-            "enum": ["fiction", "non-fiction"],
-            "title": "Fiction"
-          },
-          "quality_check_on": {
-            "type": "boolean",
-            "title": "Quality Check On"
-          },
+          "fiction": { "type": "string", "enum": ["fiction", "non-fiction"], "title": "Fiction" },
+          "quality_check_on": { "type": "boolean", "title": "Quality Check On" },
           "quality_check_on_when_bulk_convert": {
             "type": "boolean",
             "title": "Quality Check On When Bulk Convert"
           },
-          "creation_meta": {
-            "$ref": "#/components/schemas/ProjectCreationMetaResponseModel"
-          }
+          "creation_meta": { "$ref": "#/components/schemas/ProjectCreationMetaResponseModel" }
         },
         "type": "object",
         "required": [
@@ -10312,28 +9545,12 @@
       },
       "ProjectSnapshotResponseModel": {
         "properties": {
-          "project_snapshot_id": {
-            "type": "string",
-            "title": "Project Snapshot Id"
-          },
-          "project_id": {
-            "type": "string",
-            "title": "Project Id"
-          },
-          "created_at_unix": {
-            "type": "integer",
-            "title": "Created At Unix"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "audio_upload": {
-            "$ref": "#/components/schemas/ProjectSnapshotUploadResponseModel"
-          },
-          "zip_upload": {
-            "$ref": "#/components/schemas/ProjectSnapshotUploadResponseModel"
-          }
+          "project_snapshot_id": { "type": "string", "title": "Project Snapshot Id" },
+          "project_id": { "type": "string", "title": "Project Id" },
+          "created_at_unix": { "type": "integer", "title": "Created At Unix" },
+          "name": { "type": "string", "title": "Name" },
+          "audio_upload": { "$ref": "#/components/schemas/ProjectSnapshotUploadResponseModel" },
+          "zip_upload": { "$ref": "#/components/schemas/ProjectSnapshotUploadResponseModel" }
         },
         "type": "object",
         "required": ["project_snapshot_id", "project_id", "created_at_unix", "name"],
@@ -10346,10 +9563,7 @@
             "enum": ["success", "in_queue", "pending", "failed"],
             "title": "Status"
           },
-          "acx_volume_normalization": {
-            "type": "boolean",
-            "title": "Acx Volume Normalization"
-          }
+          "acx_volume_normalization": { "type": "boolean", "title": "Acx Volume Normalization" }
         },
         "type": "object",
         "required": ["status"],
@@ -10358,9 +9572,7 @@
       "ProjectSnapshotsResponseModel": {
         "properties": {
           "snapshots": {
-            "items": {
-              "$ref": "#/components/schemas/ProjectSnapshotResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ProjectSnapshotResponseModel" },
             "type": "array",
             "title": "Snapshots"
           }
@@ -10371,41 +9583,19 @@
       },
       "PromptAgent": {
         "properties": {
-          "prompt": {
-            "type": "string",
-            "title": "Prompt",
-            "default": ""
-          },
+          "prompt": { "type": "string", "title": "Prompt", "default": "" },
           "llm": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LLM"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/LLM" }],
             "default": "gemini-1.5-flash"
           },
-          "temperature": {
-            "type": "number",
-            "title": "Temperature",
-            "default": 0
-          },
-          "max_tokens": {
-            "type": "integer",
-            "title": "Max Tokens",
-            "default": -1
-          },
+          "temperature": { "type": "number", "title": "Temperature", "default": 0.0 },
+          "max_tokens": { "type": "integer", "title": "Max Tokens", "default": -1 },
           "tools": {
             "items": {
               "oneOf": [
-                {
-                  "$ref": "#/components/schemas/WebhookToolConfig"
-                },
-                {
-                  "$ref": "#/components/schemas/ClientToolConfig"
-                },
-                {
-                  "$ref": "#/components/schemas/SystemToolConfig"
-                }
+                { "$ref": "#/components/schemas/WebhookToolConfig" },
+                { "$ref": "#/components/schemas/ClientToolConfig" },
+                { "$ref": "#/components/schemas/SystemToolConfig" }
               ],
               "discriminator": {
                 "propertyName": "type",
@@ -10419,52 +9609,35 @@
             "type": "array",
             "title": "Tools"
           },
+          "used_tools": {
+            "items": { "$ref": "#/components/schemas/ToolConfigLocator" },
+            "type": "array",
+            "title": "Used Tools"
+          },
           "knowledge_base": {
-            "items": {
-              "$ref": "#/components/schemas/KnowledgeBaseLocator"
-            },
+            "items": { "$ref": "#/components/schemas/KnowledgeBaseLocator" },
             "type": "array",
             "title": "Knowledge Base"
           },
-          "custom_llm": {
-            "$ref": "#/components/schemas/CustomLLM"
-          }
+          "custom_llm": { "$ref": "#/components/schemas/CustomLLM" }
         },
         "type": "object",
         "title": "PromptAgent"
       },
       "PromptAgentOverride": {
-        "properties": {
-          "prompt": {
-            "type": "string",
-            "title": "Prompt",
-            "default": ""
-          }
-        },
+        "properties": { "prompt": { "type": "string", "title": "Prompt", "default": "" } },
         "type": "object",
         "title": "PromptAgentOverride"
       },
       "PromptAgentOverrideConfig": {
-        "properties": {
-          "prompt": {
-            "type": "boolean",
-            "title": "Prompt",
-            "default": false
-          }
-        },
+        "properties": { "prompt": { "type": "boolean", "title": "Prompt", "default": false } },
         "type": "object",
         "title": "PromptAgentOverrideConfig"
       },
       "PromptEvaluationCriteria": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "type": {
             "type": "string",
             "enum": ["prompt"],
@@ -10490,19 +9663,9 @@
       },
       "PronunciationDictionaryAliasRuleRequestModel": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["alias"],
-            "title": "Type"
-          },
-          "string_to_replace": {
-            "type": "string",
-            "title": "String To Replace"
-          },
-          "alias": {
-            "type": "string",
-            "title": "Alias"
-          }
+          "type": { "type": "string", "enum": ["alias"], "title": "Type" },
+          "string_to_replace": { "type": "string", "title": "String To Replace" },
+          "alias": { "type": "string", "title": "Alias" }
         },
         "type": "object",
         "required": ["type", "string_to_replace", "alias"],
@@ -10510,23 +9673,10 @@
       },
       "PronunciationDictionaryPhonemeRuleRequestModel": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["phoneme"],
-            "title": "Type"
-          },
-          "string_to_replace": {
-            "type": "string",
-            "title": "String To Replace"
-          },
-          "phoneme": {
-            "type": "string",
-            "title": "Phoneme"
-          },
-          "alphabet": {
-            "type": "string",
-            "title": "Alphabet"
-          }
+          "type": { "type": "string", "enum": ["phoneme"], "title": "Type" },
+          "string_to_replace": { "type": "string", "title": "String To Replace" },
+          "phoneme": { "type": "string", "title": "Phoneme" },
+          "alphabet": { "type": "string", "title": "Alphabet" }
         },
         "type": "object",
         "required": ["type", "string_to_replace", "phoneme", "alphabet"],
@@ -10538,10 +9688,7 @@
             "type": "string",
             "title": "Pronunciation Dictionary Id"
           },
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          }
+          "version_id": { "type": "string", "title": "Version Id" }
         },
         "type": "object",
         "required": ["pronunciation_dictionary_id", "version_id"],
@@ -10549,30 +9696,15 @@
       },
       "PronunciationDictionaryVersionResponseModel": {
         "properties": {
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          },
+          "version_id": { "type": "string", "title": "Version Id" },
           "pronunciation_dictionary_id": {
             "type": "string",
             "title": "Pronunciation Dictionary Id"
           },
-          "dictionary_name": {
-            "type": "string",
-            "title": "Dictionary Name"
-          },
-          "version_name": {
-            "type": "string",
-            "title": "Version Name"
-          },
-          "created_by": {
-            "type": "string",
-            "title": "Created By"
-          },
-          "creation_time_unix": {
-            "type": "integer",
-            "title": "Creation Time Unix"
-          }
+          "dictionary_name": { "type": "string", "title": "Dictionary Name" },
+          "version_name": { "type": "string", "title": "Version Name" },
+          "created_by": { "type": "string", "title": "Created By" },
+          "creation_time_unix": { "type": "integer", "title": "Creation Time Unix" }
         },
         "type": "object",
         "required": [
@@ -10591,10 +9723,7 @@
             "type": "string",
             "title": "Pronunciation Dictionary Id"
           },
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          }
+          "version_id": { "type": "string", "title": "Version Id" }
         },
         "type": "object",
         "required": ["pronunciation_dictionary_id", "version_id"],
@@ -10604,19 +9733,11 @@
       "QueryParamsJsonSchema": {
         "properties": {
           "properties": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-            },
+            "additionalProperties": { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
             "type": "object",
             "title": "Properties"
           },
-          "required": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Required"
-          }
+          "required": { "items": { "type": "string" }, "type": "array", "title": "Required" }
         },
         "additionalProperties": false,
         "type": "object",
@@ -10630,10 +9751,7 @@
             "enum": ["read", "collection"],
             "title": "Resource Type"
           },
-          "resource_id": {
-            "type": "string",
-            "title": "Resource Id"
-          }
+          "resource_id": { "type": "string", "title": "Resource Id" }
         },
         "type": "object",
         "required": ["resource_type", "resource_id"],
@@ -10641,26 +9759,11 @@
       },
       "RecordingResponseModel": {
         "properties": {
-          "recording_id": {
-            "type": "string",
-            "title": "Recording Id"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          },
-          "upload_date_unix": {
-            "type": "integer",
-            "title": "Upload Date Unix"
-          },
-          "transcription": {
-            "type": "string",
-            "title": "Transcription"
-          }
+          "recording_id": { "type": "string", "title": "Recording Id" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" },
+          "upload_date_unix": { "type": "integer", "title": "Upload Date Unix" },
+          "transcription": { "type": "string", "title": "Transcription" }
         },
         "type": "object",
         "required": [
@@ -10674,14 +9777,8 @@
       },
       "RemovePronunciationDictionaryRulesResponseModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version_id": {
-            "type": "string",
-            "title": "Version Id"
-          }
+          "id": { "type": "string", "title": "Id" },
+          "version_id": { "type": "string", "title": "Version Id" }
         },
         "type": "object",
         "required": ["id", "version_id"],
@@ -10689,12 +9786,8 @@
       },
       "Safety": {
         "properties": {
-          "ivc": {
-            "$ref": "#/components/schemas/SafetyEvaluation"
-          },
-          "non_ivc": {
-            "$ref": "#/components/schemas/SafetyEvaluation"
-          }
+          "ivc": { "$ref": "#/components/schemas/SafetyEvaluation" },
+          "non_ivc": { "$ref": "#/components/schemas/SafetyEvaluation" }
         },
         "type": "object",
         "title": "Safety",
@@ -10702,25 +9795,15 @@
       },
       "SafetyEvaluation": {
         "properties": {
-          "is_unsafe": {
-            "type": "boolean",
-            "title": "Is Unsafe",
-            "default": false
-          },
-          "llm_reason": {
-            "type": "string",
-            "title": "Llm Reason",
-            "default": ""
-          },
+          "is_unsafe": { "type": "boolean", "title": "Is Unsafe", "default": false },
+          "llm_reason": { "type": "string", "title": "Llm Reason", "default": "" },
           "safety_prompt_version": {
             "type": "integer",
             "title": "Safety Prompt Version",
             "default": 0
           },
           "matched_rule_id": {
-            "items": {
-              "$ref": "#/components/schemas/SafetyRule"
-            },
+            "items": { "$ref": "#/components/schemas/SafetyRule" },
             "type": "array"
           }
         },
@@ -10746,26 +9829,11 @@
       },
       "SampleResponseModel": {
         "properties": {
-          "sample_id": {
-            "type": "string",
-            "title": "Sample Id"
-          },
-          "file_name": {
-            "type": "string",
-            "title": "File Name"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          },
-          "hash": {
-            "type": "string",
-            "title": "Hash"
-          }
+          "sample_id": { "type": "string", "title": "Sample Id" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" },
+          "hash": { "type": "string", "title": "Hash" }
         },
         "type": "object",
         "required": ["sample_id", "file_name", "mime_type", "size_bytes", "hash"],
@@ -10773,75 +9841,34 @@
       },
       "SpeechHistoryItemResponseModel": {
         "properties": {
-          "history_item_id": {
-            "type": "string",
-            "title": "History Item Id"
-          },
-          "request_id": {
-            "type": "string",
-            "title": "Request Id"
-          },
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          },
-          "model_id": {
-            "type": "string",
-            "title": "Model Id"
-          },
-          "voice_name": {
-            "type": "string",
-            "title": "Voice Name"
-          },
+          "history_item_id": { "type": "string", "title": "History Item Id" },
+          "request_id": { "type": "string", "title": "Request Id" },
+          "voice_id": { "type": "string", "title": "Voice Id" },
+          "model_id": { "type": "string", "title": "Model Id" },
+          "voice_name": { "type": "string", "title": "Voice Name" },
           "voice_category": {
             "type": "string",
             "enum": ["premade", "cloned", "generated", "professional"],
             "title": "Voice Category"
           },
-          "text": {
-            "type": "string",
-            "title": "Text"
-          },
-          "date_unix": {
-            "type": "integer",
-            "title": "Date Unix"
-          },
+          "text": { "type": "string", "title": "Text" },
+          "date_unix": { "type": "integer", "title": "Date Unix" },
           "character_count_change_from": {
             "type": "integer",
             "title": "Character Count Change From"
           },
-          "character_count_change_to": {
-            "type": "integer",
-            "title": "Character Count Change To"
-          },
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
+          "character_count_change_to": { "type": "integer", "title": "Character Count Change To" },
+          "content_type": { "type": "string", "title": "Content Type" },
           "state": {
             "type": "string",
             "enum": ["created", "deleted", "processing"],
             "title": "State"
           },
-          "settings": {
-            "type": "object",
-            "title": "Settings"
-          },
-          "feedback": {
-            "$ref": "#/components/schemas/FeedbackResponseModel"
-          },
-          "share_link_id": {
-            "type": "string",
-            "title": "Share Link Id"
-          },
-          "source": {
-            "type": "string",
-            "enum": ["TTS", "STS"],
-            "title": "Source"
-          },
-          "alignments": {
-            "$ref": "#/components/schemas/HistoryAlignmentsResponseModel"
-          }
+          "settings": { "type": "object", "title": "Settings" },
+          "feedback": { "$ref": "#/components/schemas/FeedbackResponseModel" },
+          "share_link_id": { "type": "string", "title": "Share Link Id" },
+          "source": { "type": "string", "enum": ["TTS", "STS"], "title": "Source" },
+          "alignments": { "$ref": "#/components/schemas/HistoryAlignmentsResponseModel" }
         },
         "type": "object",
         "required": [
@@ -10866,34 +9893,27 @@
       },
       "SubscriptionExtrasResponseModel": {
         "properties": {
-          "concurrency": {
+          "concurrency": { "type": "integer", "title": "Concurrency" },
+          "convai_concurrency": { "type": "integer", "title": "Convai Concurrency" },
+          "convai_chars_per_minute": { "type": "integer", "title": "Convai Chars Per Minute" },
+          "convai_asr_chars_per_minute": {
             "type": "integer",
-            "title": "Concurrency"
+            "title": "Convai Asr Chars Per Minute"
           },
-          "convai_concurrency": {
-            "type": "integer",
-            "title": "Convai Concurrency"
-          },
-          "force_logging_disabled": {
-            "type": "boolean",
-            "title": "Force Logging Disabled"
-          },
+          "force_logging_disabled": { "type": "boolean", "title": "Force Logging Disabled" },
           "can_request_manual_pro_voice_verification": {
             "type": "boolean",
             "title": "Can Request Manual Pro Voice Verification"
           },
-          "can_bypass_voice_captcha": {
-            "type": "boolean",
-            "title": "Can Bypass Voice Captcha"
-          },
-          "moderation": {
-            "$ref": "#/components/schemas/ModerationStatusResponseModel"
-          }
+          "can_bypass_voice_captcha": { "type": "boolean", "title": "Can Bypass Voice Captcha" },
+          "moderation": { "$ref": "#/components/schemas/ModerationStatusResponseModel" }
         },
         "type": "object",
         "required": [
           "concurrency",
           "convai_concurrency",
+          "convai_chars_per_minute",
+          "convai_asr_chars_per_minute",
           "force_logging_disabled",
           "can_request_manual_pro_voice_verification",
           "can_bypass_voice_captcha",
@@ -10903,18 +9923,9 @@
       },
       "SubscriptionResponseModel": {
         "properties": {
-          "tier": {
-            "type": "string",
-            "title": "Tier"
-          },
-          "character_count": {
-            "type": "integer",
-            "title": "Character Count"
-          },
-          "character_limit": {
-            "type": "integer",
-            "title": "Character Limit"
-          },
+          "tier": { "type": "string", "title": "Tier" },
+          "character_count": { "type": "integer", "title": "Character Count" },
+          "character_limit": { "type": "integer", "title": "Character Limit" },
           "can_extend_character_limit": {
             "type": "boolean",
             "title": "Can Extend Character Limit"
@@ -10927,30 +9938,12 @@
             "type": "integer",
             "title": "Next Character Count Reset Unix"
           },
-          "voice_slots_used": {
-            "type": "integer",
-            "title": "Voice Slots Used"
-          },
-          "voice_limit": {
-            "type": "integer",
-            "title": "Voice Limit"
-          },
-          "max_voice_add_edits": {
-            "type": "integer",
-            "title": "Max Voice Add Edits"
-          },
-          "voice_add_edit_counter": {
-            "type": "integer",
-            "title": "Voice Add Edit Counter"
-          },
-          "professional_voice_limit": {
-            "type": "integer",
-            "title": "Professional Voice Limit"
-          },
-          "can_extend_voice_limit": {
-            "type": "boolean",
-            "title": "Can Extend Voice Limit"
-          },
+          "voice_slots_used": { "type": "integer", "title": "Voice Slots Used" },
+          "voice_limit": { "type": "integer", "title": "Voice Limit" },
+          "max_voice_add_edits": { "type": "integer", "title": "Max Voice Add Edits" },
+          "voice_add_edit_counter": { "type": "integer", "title": "Voice Add Edit Counter" },
+          "professional_voice_limit": { "type": "integer", "title": "Professional Voice Limit" },
+          "can_extend_voice_limit": { "type": "boolean", "title": "Can Extend Voice Limit" },
           "can_use_instant_voice_cloning": {
             "type": "boolean",
             "title": "Can Use Instant Voice Cloning"
@@ -10959,11 +9952,7 @@
             "type": "boolean",
             "title": "Can Use Professional Voice Cloning"
           },
-          "currency": {
-            "type": "string",
-            "enum": ["usd", "eur"],
-            "title": "Currency"
-          },
+          "currency": { "type": "string", "enum": ["usd", "eur"], "title": "Currency" },
           "status": {
             "type": "string",
             "enum": [
@@ -11014,20 +10003,9 @@
       },
       "SystemToolConfig": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["system"],
-            "title": "Type"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]{1,64}$",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          }
+          "type": { "type": "string", "enum": ["system"], "title": "Type" },
+          "name": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$", "title": "Name" },
+          "description": { "type": "string", "title": "Description" }
         },
         "type": "object",
         "required": ["type", "name", "description"],
@@ -11037,44 +10015,20 @@
       "TTSConversationalConfig": {
         "properties": {
           "model_id": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TTSConversationalModel"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/TTSConversationalModel" }],
             "default": "eleven_turbo_v2"
           },
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id",
-            "default": "cjVigY5qzO86Huf0OWal"
-          },
+          "voice_id": { "type": "string", "title": "Voice Id", "default": "cjVigY5qzO86Huf0OWal" },
           "agent_output_audio_format": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TTSOutputFormat"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/TTSOutputFormat" }],
             "default": "pcm_16000"
           },
           "optimize_streaming_latency": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TTSOptimizeStreamingLatency"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/TTSOptimizeStreamingLatency" }],
             "default": 3
           },
-          "stability": {
-            "type": "number",
-            "title": "Stability",
-            "default": 0.5
-          },
-          "similarity_boost": {
-            "type": "number",
-            "title": "Similarity Boost",
-            "default": 0.8
-          },
+          "stability": { "type": "number", "title": "Stability", "default": 0.5 },
+          "similarity_boost": { "type": "number", "title": "Similarity Boost", "default": 0.8 },
           "pronunciation_dictionary_locators": {
             "items": {
               "$ref": "#/components/schemas/PydanticPronunciationDictionaryVersionLocator"
@@ -11087,23 +10041,12 @@
         "title": "TTSConversationalConfig"
       },
       "TTSConversationalConfigOverride": {
-        "properties": {
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          }
-        },
+        "properties": { "voice_id": { "type": "string", "title": "Voice Id" } },
         "type": "object",
         "title": "TTSConversationalConfigOverride"
       },
       "TTSConversationalConfigOverrideConfig": {
-        "properties": {
-          "voice_id": {
-            "type": "boolean",
-            "title": "Voice Id",
-            "default": false
-          }
-        },
+        "properties": { "voice_id": { "type": "boolean", "title": "Voice Id", "default": false } },
         "type": "object",
         "title": "TTSConversationalConfigOverrideConfig"
       },
@@ -11131,21 +10074,63 @@
         "title": "TelephonyProvider",
         "description": "An enumeration."
       },
+      "ToolConfigLocator": {
+        "properties": { "id": { "type": "string", "title": "Id" } },
+        "type": "object",
+        "required": ["id"],
+        "title": "ToolConfigLocator"
+      },
+      "ToolRequestModel": {
+        "properties": {
+          "tool_config": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/WebhookToolConfig" },
+              { "$ref": "#/components/schemas/ClientToolConfig" },
+              { "$ref": "#/components/schemas/SystemToolConfig" }
+            ],
+            "title": "Tool Config",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "webhook": "#/components/schemas/WebhookToolConfig",
+                "client": "#/components/schemas/ClientToolConfig",
+                "system": "#/components/schemas/SystemToolConfig"
+              }
+            }
+          }
+        },
+        "type": "object",
+        "required": ["tool_config"],
+        "title": "ToolRequestModel"
+      },
+      "ToolResponseModel": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "tool_config": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/WebhookToolConfig" },
+              { "$ref": "#/components/schemas/ClientToolConfig" },
+              { "$ref": "#/components/schemas/SystemToolConfig" }
+            ],
+            "title": "Tool Config",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "webhook": "#/components/schemas/WebhookToolConfig",
+                "client": "#/components/schemas/ClientToolConfig",
+                "system": "#/components/schemas/SystemToolConfig"
+              }
+            }
+          }
+        },
+        "type": "object",
+        "required": ["id", "tool_config"],
+        "title": "ToolResponseModel"
+      },
       "TurnConfig": {
         "properties": {
-          "turn_timeout": {
-            "type": "number",
-            "title": "Turn Timeout",
-            "default": 7
-          },
-          "mode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TurnMode"
-              }
-            ],
-            "default": "turn"
-          }
+          "turn_timeout": { "type": "number", "title": "Turn Timeout", "default": 7.0 },
+          "mode": { "allOf": [{ "$ref": "#/components/schemas/TurnMode" }], "default": "turn" }
         },
         "type": "object",
         "title": "TurnConfig"
@@ -11158,47 +10143,22 @@
       },
       "URLAvatar": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["url"],
-            "title": "Type",
-            "default": "url"
-          },
-          "custom_url": {
-            "type": "string",
-            "title": "Custom Url",
-            "default": ""
-          }
+          "type": { "type": "string", "enum": ["url"], "title": "Type", "default": "url" },
+          "custom_url": { "type": "string", "title": "Custom Url", "default": "" }
         },
         "type": "object",
         "title": "URLAvatar"
       },
       "UpdatePhoneNumberRequest": {
-        "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          }
-        },
+        "properties": { "agent_id": { "type": "string", "title": "Agent Id" } },
         "type": "object",
         "title": "UpdatePhoneNumberRequest"
       },
       "UsageCharactersResponseModel": {
         "properties": {
-          "time": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array",
-            "title": "Time"
-          },
+          "time": { "items": { "type": "integer" }, "type": "array", "title": "Time" },
           "usage": {
-            "additionalProperties": {
-              "items": {
-                "type": "integer"
-              },
-              "type": "array"
-            },
+            "additionalProperties": { "items": { "type": "integer" }, "type": "array" },
             "type": "object",
             "title": "Usage"
           }
@@ -11209,13 +10169,8 @@
       },
       "UserFeedback": {
         "properties": {
-          "score": {
-            "$ref": "#/components/schemas/UserFeedbackScore"
-          },
-          "time_in_call_secs": {
-            "type": "integer",
-            "title": "Time In Call Secs"
-          }
+          "score": { "$ref": "#/components/schemas/UserFeedbackScore" },
+          "time_in_call_secs": { "type": "integer", "title": "Time In Call Secs" }
         },
         "type": "object",
         "required": ["score", "time_in_call_secs"],
@@ -11229,53 +10184,28 @@
       },
       "UserResponseModel": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "subscription": {
-            "$ref": "#/components/schemas/SubscriptionResponseModel"
-          },
-          "subscription_extras": {
-            "$ref": "#/components/schemas/SubscriptionExtrasResponseModel"
-          },
-          "is_new_user": {
-            "type": "boolean",
-            "title": "Is New User"
-          },
-          "xi_api_key": {
-            "type": "string",
-            "title": "Xi Api Key"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "subscription": { "$ref": "#/components/schemas/SubscriptionResponseModel" },
+          "subscription_extras": { "$ref": "#/components/schemas/SubscriptionExtrasResponseModel" },
+          "is_new_user": { "type": "boolean", "title": "Is New User" },
+          "xi_api_key": { "type": "string", "title": "Xi Api Key" },
           "can_use_delayed_payment_methods": {
             "type": "boolean",
             "title": "Can Use Delayed Payment Methods"
           },
-          "is_onboarding_completed": {
-            "type": "boolean",
-            "title": "Is Onboarding Completed"
-          },
+          "is_onboarding_completed": { "type": "boolean", "title": "Is Onboarding Completed" },
           "is_onboarding_checklist_completed": {
             "type": "boolean",
             "title": "Is Onboarding Checklist Completed"
           },
-          "first_name": {
-            "type": "string",
-            "title": "First Name"
-          },
+          "first_name": { "type": "string", "title": "First Name" },
           "is_api_key_hashed": {
             "type": "boolean",
             "title": "Is Api Key Hashed",
             "default": false
           },
-          "xi_api_key_preview": {
-            "type": "string",
-            "title": "Xi Api Key Preview"
-          },
-          "referral_link_code": {
-            "type": "string",
-            "title": "Referral Link Code"
-          },
+          "xi_api_key_preview": { "type": "string", "title": "Xi Api Key Preview" },
+          "referral_link_code": { "type": "string", "title": "Referral Link Code" },
           "partnerstack_partner_default_link": {
             "type": "string",
             "title": "Partnerstack Partner Default Link"
@@ -11297,27 +10227,12 @@
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
             "type": "array",
             "title": "Location"
           },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
@@ -11325,29 +10240,12 @@
       },
       "VerificationAttemptResponseModel": {
         "properties": {
-          "text": {
-            "type": "string",
-            "title": "Text"
-          },
-          "date_unix": {
-            "type": "integer",
-            "title": "Date Unix"
-          },
-          "accepted": {
-            "type": "boolean",
-            "title": "Accepted"
-          },
-          "similarity": {
-            "type": "number",
-            "title": "Similarity"
-          },
-          "levenshtein_distance": {
-            "type": "number",
-            "title": "Levenshtein Distance"
-          },
-          "recording": {
-            "$ref": "#/components/schemas/RecordingResponseModel"
-          }
+          "text": { "type": "string", "title": "Text" },
+          "date_unix": { "type": "integer", "title": "Date Unix" },
+          "accepted": { "type": "boolean", "title": "Accepted" },
+          "similarity": { "type": "number", "title": "Similarity" },
+          "levenshtein_distance": { "type": "number", "title": "Levenshtein Distance" },
+          "recording": { "$ref": "#/components/schemas/RecordingResponseModel" }
         },
         "type": "object",
         "required": ["text", "date_unix", "accepted", "similarity", "levenshtein_distance"],
@@ -11355,14 +10253,8 @@
       },
       "VoiceGenerationParameterOptionResponseModel": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "code": {
-            "type": "string",
-            "title": "Code"
-          }
+          "name": { "type": "string", "title": "Name" },
+          "code": { "type": "string", "title": "Code" }
         },
         "type": "object",
         "required": ["name", "code"],
@@ -11371,42 +10263,24 @@
       "VoiceGenerationParameterResponseModel": {
         "properties": {
           "genders": {
-            "items": {
-              "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel" },
             "type": "array",
             "title": "Genders"
           },
           "accents": {
-            "items": {
-              "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel" },
             "type": "array",
             "title": "Accents"
           },
           "ages": {
-            "items": {
-              "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VoiceGenerationParameterOptionResponseModel" },
             "type": "array",
             "title": "Ages"
           },
-          "minimum_characters": {
-            "type": "integer",
-            "title": "Minimum Characters"
-          },
-          "maximum_characters": {
-            "type": "integer",
-            "title": "Maximum Characters"
-          },
-          "minimum_accent_strength": {
-            "type": "number",
-            "title": "Minimum Accent Strength"
-          },
-          "maximum_accent_strength": {
-            "type": "number",
-            "title": "Maximum Accent Strength"
-          }
+          "minimum_characters": { "type": "integer", "title": "Minimum Characters" },
+          "maximum_characters": { "type": "integer", "title": "Maximum Characters" },
+          "minimum_accent_strength": { "type": "number", "title": "Minimum Accent Strength" },
+          "maximum_accent_strength": { "type": "number", "title": "Maximum Accent Strength" }
         },
         "type": "object",
         "required": [
@@ -11422,22 +10296,10 @@
       },
       "VoicePreviewResponseModel": {
         "properties": {
-          "audio_base_64": {
-            "type": "string",
-            "title": "Audio Base 64"
-          },
-          "generated_voice_id": {
-            "type": "string",
-            "title": "Generated Voice Id"
-          },
-          "media_type": {
-            "type": "string",
-            "title": "Media Type"
-          },
-          "duration_secs": {
-            "type": "number",
-            "title": "Duration Secs"
-          }
+          "audio_base_64": { "type": "string", "title": "Audio Base 64" },
+          "generated_voice_id": { "type": "string", "title": "Generated Voice Id" },
+          "media_type": { "type": "string", "title": "Media Type" },
+          "duration_secs": { "type": "number", "title": "Duration Secs" }
         },
         "type": "object",
         "required": ["audio_base_64", "generated_voice_id", "media_type", "duration_secs"],
@@ -11477,16 +10339,11 @@
       "VoicePreviewsResponseModel": {
         "properties": {
           "previews": {
-            "items": {
-              "$ref": "#/components/schemas/VoicePreviewResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VoicePreviewResponseModel" },
             "type": "array",
             "title": "Previews"
           },
-          "text": {
-            "type": "string",
-            "title": "Text"
-          }
+          "text": { "type": "string", "title": "Text" }
         },
         "type": "object",
         "required": ["previews", "text"],
@@ -11494,18 +10351,10 @@
       },
       "VoiceResponseModel": {
         "properties": {
-          "voice_id": {
-            "type": "string",
-            "title": "Voice Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "voice_id": { "type": "string", "title": "Voice Id" },
+          "name": { "type": "string", "title": "Name" },
           "samples": {
-            "items": {
-              "$ref": "#/components/schemas/SampleResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/SampleResponseModel" },
             "type": "array",
             "title": "Samples"
           },
@@ -11514,41 +10363,23 @@
             "enum": ["generated", "cloned", "premade", "professional", "famous", "high_quality"],
             "title": "Category"
           },
-          "fine_tuning": {
-            "$ref": "#/components/schemas/FineTuningResponseModel"
-          },
+          "fine_tuning": { "$ref": "#/components/schemas/FineTuningResponseModel" },
           "labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Labels"
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "preview_url": {
-            "type": "string",
-            "title": "Preview Url"
-          },
+          "description": { "type": "string", "title": "Description" },
+          "preview_url": { "type": "string", "title": "Preview Url" },
           "available_for_tiers": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Available For Tiers"
           },
-          "settings": {
-            "$ref": "#/components/schemas/VoiceSettingsResponseModel"
-          },
-          "sharing": {
-            "$ref": "#/components/schemas/VoiceSharingResponseModel"
-          },
+          "settings": { "$ref": "#/components/schemas/VoiceSettingsResponseModel" },
+          "sharing": { "$ref": "#/components/schemas/VoiceSharingResponseModel" },
           "high_quality_base_model_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "High Quality Base Model Ids"
           },
@@ -11564,31 +10395,12 @@
             ],
             "title": "Safety Control"
           },
-          "voice_verification": {
-            "$ref": "#/components/schemas/VoiceVerificationResponseModel"
-          },
-          "permission_on_resource": {
-            "type": "string",
-            "title": "Permission On Resource"
-          },
-          "is_owner": {
-            "type": "boolean",
-            "title": "Is Owner"
-          },
-          "is_legacy": {
-            "type": "boolean",
-            "title": "Is Legacy",
-            "default": false
-          },
-          "is_mixed": {
-            "type": "boolean",
-            "title": "Is Mixed",
-            "default": false
-          },
-          "created_at_unix": {
-            "type": "integer",
-            "title": "Created At Unix"
-          }
+          "voice_verification": { "$ref": "#/components/schemas/VoiceVerificationResponseModel" },
+          "permission_on_resource": { "type": "string", "title": "Permission On Resource" },
+          "is_owner": { "type": "boolean", "title": "Is Owner" },
+          "is_legacy": { "type": "boolean", "title": "Is Legacy", "default": false },
+          "is_mixed": { "type": "boolean", "title": "Is Mixed", "default": false },
+          "created_at_unix": { "type": "integer", "title": "Created At Unix" }
         },
         "type": "object",
         "required": [
@@ -11609,24 +10421,10 @@
       },
       "VoiceSettingsResponseModel": {
         "properties": {
-          "stability": {
-            "type": "number",
-            "title": "Stability"
-          },
-          "similarity_boost": {
-            "type": "number",
-            "title": "Similarity Boost"
-          },
-          "style": {
-            "type": "number",
-            "title": "Style",
-            "default": 0
-          },
-          "use_speaker_boost": {
-            "type": "boolean",
-            "title": "Use Speaker Boost",
-            "default": true
-          }
+          "stability": { "type": "number", "title": "Stability" },
+          "similarity_boost": { "type": "number", "title": "Similarity Boost" },
+          "style": { "type": "number", "title": "Style", "default": 0.0 },
+          "use_speaker_boost": { "type": "boolean", "title": "Use Speaker Boost", "default": true }
         },
         "type": "object",
         "required": ["stability", "similarity_boost"],
@@ -11634,51 +10432,20 @@
       },
       "VoiceSharingModerationCheckResponseModel": {
         "properties": {
-          "date_checked_unix": {
-            "type": "integer",
-            "title": "Date Checked Unix"
-          },
-          "name_value": {
-            "type": "string",
-            "title": "Name Value"
-          },
-          "name_check": {
-            "type": "boolean",
-            "title": "Name Check"
-          },
-          "description_value": {
-            "type": "string",
-            "title": "Description Value"
-          },
-          "description_check": {
-            "type": "boolean",
-            "title": "Description Check"
-          },
-          "sample_ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Sample Ids"
-          },
+          "date_checked_unix": { "type": "integer", "title": "Date Checked Unix" },
+          "name_value": { "type": "string", "title": "Name Value" },
+          "name_check": { "type": "boolean", "title": "Name Check" },
+          "description_value": { "type": "string", "title": "Description Value" },
+          "description_check": { "type": "boolean", "title": "Description Check" },
+          "sample_ids": { "items": { "type": "string" }, "type": "array", "title": "Sample Ids" },
           "sample_checks": {
-            "items": {
-              "type": "number"
-            },
+            "items": { "type": "number" },
             "type": "array",
             "title": "Sample Checks"
           },
-          "captcha_ids": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Captcha Ids"
-          },
+          "captcha_ids": { "items": { "type": "string" }, "type": "array", "title": "Captcha Ids" },
           "captcha_checks": {
-            "items": {
-              "type": "number"
-            },
+            "items": { "type": "number" },
             "type": "array",
             "title": "Captcha Checks"
           }
@@ -11693,98 +10460,37 @@
             "enum": ["enabled", "disabled", "copied", "copied_disabled"],
             "title": "Status"
           },
-          "history_item_sample_id": {
-            "type": "string",
-            "title": "History Item Sample Id"
-          },
-          "date_unix": {
-            "type": "integer",
-            "title": "Date Unix"
-          },
+          "history_item_sample_id": { "type": "string", "title": "History Item Sample Id" },
+          "date_unix": { "type": "integer", "title": "Date Unix" },
           "whitelisted_emails": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Whitelisted Emails"
           },
-          "public_owner_id": {
-            "type": "string",
-            "title": "Public Owner Id"
-          },
-          "original_voice_id": {
-            "type": "string",
-            "title": "Original Voice Id"
-          },
-          "financial_rewards_enabled": {
-            "type": "boolean",
-            "title": "Financial Rewards Enabled"
-          },
-          "free_users_allowed": {
-            "type": "boolean",
-            "title": "Free Users Allowed"
-          },
-          "live_moderation_enabled": {
-            "type": "boolean",
-            "title": "Live Moderation Enabled"
-          },
-          "rate": {
-            "type": "number",
-            "title": "Rate"
-          },
-          "notice_period": {
-            "type": "integer",
-            "title": "Notice Period"
-          },
-          "disable_at_unix": {
-            "type": "integer",
-            "title": "Disable At Unix"
-          },
-          "voice_mixing_allowed": {
-            "type": "boolean",
-            "title": "Voice Mixing Allowed"
-          },
-          "featured": {
-            "type": "boolean",
-            "title": "Featured"
-          },
+          "public_owner_id": { "type": "string", "title": "Public Owner Id" },
+          "original_voice_id": { "type": "string", "title": "Original Voice Id" },
+          "financial_rewards_enabled": { "type": "boolean", "title": "Financial Rewards Enabled" },
+          "free_users_allowed": { "type": "boolean", "title": "Free Users Allowed" },
+          "live_moderation_enabled": { "type": "boolean", "title": "Live Moderation Enabled" },
+          "rate": { "type": "number", "title": "Rate" },
+          "notice_period": { "type": "integer", "title": "Notice Period" },
+          "disable_at_unix": { "type": "integer", "title": "Disable At Unix" },
+          "voice_mixing_allowed": { "type": "boolean", "title": "Voice Mixing Allowed" },
+          "featured": { "type": "boolean", "title": "Featured" },
           "category": {
             "type": "string",
             "enum": ["generated", "professional", "high_quality", "famous"],
             "title": "Category"
           },
-          "reader_app_enabled": {
-            "type": "boolean",
-            "title": "Reader App Enabled"
-          },
-          "image_url": {
-            "type": "string",
-            "title": "Image Url"
-          },
-          "ban_reason": {
-            "type": "string",
-            "title": "Ban Reason"
-          },
-          "liked_by_count": {
-            "type": "integer",
-            "title": "Liked By Count"
-          },
-          "cloned_by_count": {
-            "type": "integer",
-            "title": "Cloned By Count"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "reader_app_enabled": { "type": "boolean", "title": "Reader App Enabled" },
+          "image_url": { "type": "string", "title": "Image Url" },
+          "ban_reason": { "type": "string", "title": "Ban Reason" },
+          "liked_by_count": { "type": "integer", "title": "Liked By Count" },
+          "cloned_by_count": { "type": "integer", "title": "Cloned By Count" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "labels": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Labels"
           },
@@ -11793,37 +10499,17 @@
             "enum": ["not_requested", "pending", "declined", "allowed", "allowed_with_changes"],
             "title": "Review Status"
           },
-          "review_message": {
-            "type": "string",
-            "title": "Review Message"
-          },
-          "enabled_in_library": {
-            "type": "boolean",
-            "title": "Enabled In Library"
-          },
-          "instagram_username": {
-            "type": "string",
-            "title": "Instagram Username"
-          },
-          "twitter_username": {
-            "type": "string",
-            "title": "Twitter Username"
-          },
-          "youtube_username": {
-            "type": "string",
-            "title": "Youtube Username"
-          },
-          "tiktok_username": {
-            "type": "string",
-            "title": "Tiktok Username"
-          },
+          "review_message": { "type": "string", "title": "Review Message" },
+          "enabled_in_library": { "type": "boolean", "title": "Enabled In Library" },
+          "instagram_username": { "type": "string", "title": "Instagram Username" },
+          "twitter_username": { "type": "string", "title": "Twitter Username" },
+          "youtube_username": { "type": "string", "title": "Youtube Username" },
+          "tiktok_username": { "type": "string", "title": "Tiktok Username" },
           "moderation_check": {
             "$ref": "#/components/schemas/VoiceSharingModerationCheckResponseModel"
           },
           "reader_restricted_on": {
-            "items": {
-              "$ref": "#/components/schemas/ReaderResourceResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/ReaderResourceResponseModel" },
             "type": "array",
             "title": "Reader Restricted On"
           }
@@ -11861,18 +10547,10 @@
       },
       "VoiceVerificationResponseModel": {
         "properties": {
-          "requires_verification": {
-            "type": "boolean",
-            "title": "Requires Verification"
-          },
-          "is_verified": {
-            "type": "boolean",
-            "title": "Is Verified"
-          },
+          "requires_verification": { "type": "boolean", "title": "Requires Verification" },
+          "is_verified": { "type": "boolean", "title": "Is Verified" },
           "verification_failures": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Verification Failures"
           },
@@ -11880,14 +10558,9 @@
             "type": "integer",
             "title": "Verification Attempts Count"
           },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
+          "language": { "type": "string", "title": "Language" },
           "verification_attempts": {
-            "items": {
-              "$ref": "#/components/schemas/VerificationAttemptResponseModel"
-            },
+            "items": { "$ref": "#/components/schemas/VerificationAttemptResponseModel" },
             "type": "array",
             "title": "Verification Attempts"
           }
@@ -11903,10 +10576,7 @@
       },
       "WebhookToolApiSchemaConfig": {
         "properties": {
-          "url": {
-            "type": "string",
-            "title": "Url"
-          },
+          "url": { "type": "string", "title": "Url" },
           "method": {
             "type": "string",
             "enum": ["GET", "POST", "PATCH", "DELETE"],
@@ -11914,27 +10584,17 @@
             "default": "GET"
           },
           "path_params_schema": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/LiteralJsonSchemaProperty"
-            },
+            "additionalProperties": { "$ref": "#/components/schemas/LiteralJsonSchemaProperty" },
             "type": "object",
             "title": "Path Params Schema"
           },
-          "query_params_schema": {
-            "$ref": "#/components/schemas/QueryParamsJsonSchema"
-          },
-          "request_body_schema": {
-            "$ref": "#/components/schemas/ObjectJsonSchemaProperty"
-          },
+          "query_params_schema": { "$ref": "#/components/schemas/QueryParamsJsonSchema" },
+          "request_body_schema": { "$ref": "#/components/schemas/ObjectJsonSchemaProperty" },
           "request_headers": {
             "additionalProperties": {
               "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/components/schemas/ConvAISecretLocator"
-                }
+                { "type": "string" },
+                { "$ref": "#/components/schemas/ConvAISecretLocator" }
               ]
             },
             "type": "object",
@@ -11948,23 +10608,10 @@
       },
       "WebhookToolConfig": {
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["webhook"],
-            "title": "Type"
-          },
-          "name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]{1,64}$",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "api_schema": {
-            "$ref": "#/components/schemas/WebhookToolApiSchemaConfig"
-          }
+          "type": { "type": "string", "enum": ["webhook"], "title": "Type" },
+          "name": { "type": "string", "pattern": "^[a-zA-Z0-9_-]{1,64}$", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "api_schema": { "$ref": "#/components/schemas/WebhookToolApiSchemaConfig" }
         },
         "type": "object",
         "required": ["type", "name", "description", "api_schema"],
@@ -11974,122 +10621,45 @@
       "WidgetConfig": {
         "properties": {
           "variant": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EmbedVariant"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/EmbedVariant" }],
             "default": "full"
           },
           "avatar": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/OrbAvatar"
-              },
-              {
-                "$ref": "#/components/schemas/URLAvatar"
-              },
-              {
-                "$ref": "#/components/schemas/ImageAvatar"
-              }
+              { "$ref": "#/components/schemas/OrbAvatar" },
+              { "$ref": "#/components/schemas/URLAvatar" },
+              { "$ref": "#/components/schemas/ImageAvatar" }
             ],
             "title": "Avatar"
           },
           "feedback_mode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/WidgetFeedbackMode"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/WidgetFeedbackMode" }],
             "default": "none"
           },
-          "bg_color": {
-            "type": "string",
-            "title": "Bg Color",
-            "default": "#ffffff"
-          },
-          "text_color": {
-            "type": "string",
-            "title": "Text Color",
-            "default": "#000000"
-          },
-          "btn_color": {
-            "type": "string",
-            "title": "Btn Color",
-            "default": "#000000"
-          },
-          "btn_text_color": {
-            "type": "string",
-            "title": "Btn Text Color",
-            "default": "#ffffff"
-          },
-          "border_color": {
-            "type": "string",
-            "title": "Border Color",
-            "default": "#e1e1e1"
-          },
-          "focus_color": {
-            "type": "string",
-            "title": "Focus Color",
-            "default": "#000000"
-          },
-          "border_radius": {
-            "type": "integer",
-            "title": "Border Radius"
-          },
-          "btn_radius": {
-            "type": "integer",
-            "title": "Btn Radius"
-          },
-          "action_text": {
-            "type": "string",
-            "title": "Action Text"
-          },
-          "start_call_text": {
-            "type": "string",
-            "title": "Start Call Text"
-          },
-          "end_call_text": {
-            "type": "string",
-            "title": "End Call Text"
-          },
-          "expand_text": {
-            "type": "string",
-            "title": "Expand Text"
-          },
-          "listening_text": {
-            "type": "string",
-            "title": "Listening Text"
-          },
-          "speaking_text": {
-            "type": "string",
-            "title": "Speaking Text"
-          },
-          "shareable_page_text": {
-            "type": "string",
-            "title": "Shareable Page Text"
-          },
-          "terms_text": {
-            "type": "string",
-            "title": "Terms Text"
-          },
-          "terms_html": {
-            "type": "string",
-            "title": "Terms Html"
-          },
-          "terms_key": {
-            "type": "string",
-            "title": "Terms Key"
-          },
+          "bg_color": { "type": "string", "title": "Bg Color", "default": "#ffffff" },
+          "text_color": { "type": "string", "title": "Text Color", "default": "#000000" },
+          "btn_color": { "type": "string", "title": "Btn Color", "default": "#000000" },
+          "btn_text_color": { "type": "string", "title": "Btn Text Color", "default": "#ffffff" },
+          "border_color": { "type": "string", "title": "Border Color", "default": "#e1e1e1" },
+          "focus_color": { "type": "string", "title": "Focus Color", "default": "#000000" },
+          "border_radius": { "type": "integer", "title": "Border Radius" },
+          "btn_radius": { "type": "integer", "title": "Btn Radius" },
+          "action_text": { "type": "string", "title": "Action Text" },
+          "start_call_text": { "type": "string", "title": "Start Call Text" },
+          "end_call_text": { "type": "string", "title": "End Call Text" },
+          "expand_text": { "type": "string", "title": "Expand Text" },
+          "listening_text": { "type": "string", "title": "Listening Text" },
+          "speaking_text": { "type": "string", "title": "Speaking Text" },
+          "shareable_page_text": { "type": "string", "title": "Shareable Page Text" },
+          "terms_text": { "type": "string", "title": "Terms Text" },
+          "terms_html": { "type": "string", "title": "Terms Html" },
+          "terms_key": { "type": "string", "title": "Terms Key" },
           "language_selector": {
             "type": "boolean",
             "title": "Language Selector",
             "default": false
           },
-          "custom_avatar_path": {
-            "type": "string",
-            "title": "Custom Avatar Path"
-          }
+          "custom_avatar_path": { "type": "string", "title": "Custom Avatar Path" }
         },
         "type": "object",
         "title": "WidgetConfig"
@@ -12097,121 +10667,42 @@
       "WidgetConfigResponseModel": {
         "properties": {
           "variant": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EmbedVariant"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/EmbedVariant" }],
             "default": "full"
           },
           "avatar": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/OrbAvatar"
-              },
-              {
-                "$ref": "#/components/schemas/URLAvatar"
-              },
-              {
-                "$ref": "#/components/schemas/ImageAvatar"
-              }
+              { "$ref": "#/components/schemas/OrbAvatar" },
+              { "$ref": "#/components/schemas/URLAvatar" },
+              { "$ref": "#/components/schemas/ImageAvatar" }
             ],
             "title": "Avatar"
           },
           "feedback_mode": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/WidgetFeedbackMode"
-              }
-            ],
+            "allOf": [{ "$ref": "#/components/schemas/WidgetFeedbackMode" }],
             "default": "none"
           },
-          "bg_color": {
-            "type": "string",
-            "title": "Bg Color",
-            "default": "#ffffff"
-          },
-          "text_color": {
-            "type": "string",
-            "title": "Text Color",
-            "default": "#000000"
-          },
-          "btn_color": {
-            "type": "string",
-            "title": "Btn Color",
-            "default": "#000000"
-          },
-          "btn_text_color": {
-            "type": "string",
-            "title": "Btn Text Color",
-            "default": "#ffffff"
-          },
-          "border_color": {
-            "type": "string",
-            "title": "Border Color",
-            "default": "#e1e1e1"
-          },
-          "focus_color": {
-            "type": "string",
-            "title": "Focus Color",
-            "default": "#000000"
-          },
-          "border_radius": {
-            "type": "integer",
-            "title": "Border Radius"
-          },
-          "btn_radius": {
-            "type": "integer",
-            "title": "Btn Radius"
-          },
-          "action_text": {
-            "type": "string",
-            "title": "Action Text"
-          },
-          "start_call_text": {
-            "type": "string",
-            "title": "Start Call Text"
-          },
-          "end_call_text": {
-            "type": "string",
-            "title": "End Call Text"
-          },
-          "expand_text": {
-            "type": "string",
-            "title": "Expand Text"
-          },
-          "listening_text": {
-            "type": "string",
-            "title": "Listening Text"
-          },
-          "speaking_text": {
-            "type": "string",
-            "title": "Speaking Text"
-          },
-          "shareable_page_text": {
-            "type": "string",
-            "title": "Shareable Page Text"
-          },
-          "terms_text": {
-            "type": "string",
-            "title": "Terms Text"
-          },
-          "terms_html": {
-            "type": "string",
-            "title": "Terms Html"
-          },
-          "terms_key": {
-            "type": "string",
-            "title": "Terms Key"
-          },
-          "language": {
-            "type": "string",
-            "title": "Language"
-          },
+          "bg_color": { "type": "string", "title": "Bg Color", "default": "#ffffff" },
+          "text_color": { "type": "string", "title": "Text Color", "default": "#000000" },
+          "btn_color": { "type": "string", "title": "Btn Color", "default": "#000000" },
+          "btn_text_color": { "type": "string", "title": "Btn Text Color", "default": "#ffffff" },
+          "border_color": { "type": "string", "title": "Border Color", "default": "#e1e1e1" },
+          "focus_color": { "type": "string", "title": "Focus Color", "default": "#000000" },
+          "border_radius": { "type": "integer", "title": "Border Radius" },
+          "btn_radius": { "type": "integer", "title": "Btn Radius" },
+          "action_text": { "type": "string", "title": "Action Text" },
+          "start_call_text": { "type": "string", "title": "Start Call Text" },
+          "end_call_text": { "type": "string", "title": "End Call Text" },
+          "expand_text": { "type": "string", "title": "Expand Text" },
+          "listening_text": { "type": "string", "title": "Listening Text" },
+          "speaking_text": { "type": "string", "title": "Speaking Text" },
+          "shareable_page_text": { "type": "string", "title": "Shareable Page Text" },
+          "terms_text": { "type": "string", "title": "Terms Text" },
+          "terms_html": { "type": "string", "title": "Terms Html" },
+          "terms_key": { "type": "string", "title": "Terms Key" },
+          "language": { "type": "string", "title": "Language" },
           "supported_language_overrides": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Supported Language Overrides"
           }
@@ -12237,14 +10728,8 @@
       "name": "speech-to-speech",
       "description": "Create speech by combining the style and content of an audio file you upload with a voice of your choice."
     },
-    {
-      "name": "models",
-      "description": "Access the different models of the platform."
-    },
-    {
-      "name": "voices",
-      "description": "Access to voices created either by you or us."
-    },
+    { "name": "models", "description": "Access the different models of the platform." },
+    { "name": "voices", "description": "Access to voices created either by you or us." },
     {
       "name": "samples",
       "description": "Access to your samples. A sample is any audio file you attached to a voice. A voice can have one or more samples."

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -5676,9 +5676,7 @@
             }
           }
         },
-        "deprecated": true,
-        "x-fern-sdk-group-name": "conversational_ai",
-        "x-fern-sdk-method-name": "add_to_knowledge_base"
+        "deprecated": true
       }
     },
     "/v1/convai/agents/{agent_id}/add-to-knowledge-base": {
@@ -5740,9 +5738,7 @@
             }
           }
         },
-        "deprecated": true,
-        "x-fern-sdk-group-name": "conversational_ai",
-        "x-fern-sdk-method-name": "add_to_knowledge_base"
+        "deprecated": true
       }
     },
     "/v1/convai/knowledge-base/{documentation_id}": {
@@ -5862,9 +5858,7 @@
             }
           }
         },
-        "deprecated": true,
-        "x-fern-sdk-group-name": "conversational_ai",
-        "x-fern-sdk-method-name": "get_knowledge_base_document_by_id"
+        "deprecated": true
       }
     },
     "/v1/convai/add-tool": {

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -494,6 +494,8 @@ navigation:
                     slug: /chapters/get-chapter
                   - endpoint: POST /v1/projects/{project_id}/chapters/add
                     slug: /chapters/add-chapter
+                  - endpoint: PATCH /v1/projects/{project_id}/chapters/{chapter_id}
+                    slug: /chapters/patch-chapter
                   - endpoint: DELETE /v1/projects/{project_id}/chapters/{chapter_id}
                     slug: /chapters/delete-chapter
                   - endpoint: POST /v1/projects/{project_id}/chapters/{chapter_id}/convert
@@ -502,6 +504,8 @@ navigation:
                     slug: /chapters/get-snapshots
                   - endpoint: POST /v1/projects/{project_id}/chapters/{chapter_id}/snapshots/{chapter_snapshot_id}/stream
                     slug: /chapters/stream-snapshot
+                  - endpoint: POST /v1/projects/podcast/create
+                    slug: /projects/create-podcast
                   - endpoint: POST /v1/projects/{project_id}/update-pronunciation-dictionaries
                     slug: /projects/update-pronunciation-dictionaries
               - pronunciationDictionary

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format:check": "prettier \"**/*.{css,js,ts,tsx,md,mdx,yml,yaml,json}\" --check",
     "fern:upgrade": "fern upgrade",
     "fern:check": "fern check",
-    "fern:preview": "fern generate --docs --preview"
+    "fern:preview": "fern generate --docs --preview",
+    "openapi:latest": "curl -o ./fern/apis/api/openapi.json https://api.elevenlabs.io/openapi.json"
   },
   "keywords": [
     "elevenlabs",


### PR DESCRIPTION
Will leave this in draft until I have the accompanying SDK PR ready. I basically ran `curl -o openapi.json https://api.elevenlabs.io/openapi.json ` to update the `openapi.json` file and then added overrides to include the new endpoints in the correct places.

Was surprised to see the diff, but seems to mostly be formatting changes. Also ran `npm run format` to make sure the correct prettier config was being picked up, which I also double-checked with the prettier logs:

```
["INFO" - 09:23:48] Using config file at /Users/isaacaderogba/Documents/eleven/elevenlabs-docs/.prettierrc
```