### PR TITLE
Fix typo in react convAI description page

### DIFF
--- a/fern/conversational-ai/pages/libraries/react.mdx
+++ b/fern/conversational-ai/pages/libraries/react.mdx
@@ -56,9 +56,9 @@ const conversation = useConversation({
 
 #### Methods
 
-**startConversation**
+**startSession**
 
-`startConversation` method kick off the websocket connection and starts using microphone to communicate with the ElevenLabs Conversational AI agent.  
+`startSession` method kick off the websocket connection and starts using microphone to communicate with the ElevenLabs Conversational AI agent.
 The method accepts options object, with the `url` or `agentId` option being required.
 
 Agent ID can be acquired through [ElevenLabs UI](https://elevenlabs.io/app/conversational-ai) and is always necessary.
@@ -92,7 +92,7 @@ if (!response.ok) {
 }
 
 const body = await response.json();
-const url = body.signed_url; // use this URL for startConversation method.
+const url = body.signed_url; // use this URL for startSession method.
 ```
 
 **endSession**


### PR DESCRIPTION
The method is called startSession, not startConversation