### PR TITLE
Link to developer tutorial instead of quickstart

### DIFF
--- a/fern/docs/pages/capabilities/speech-to-text.mdx
+++ b/fern/docs/pages/capabilities/speech-to-text.mdx
@@ -13,7 +13,11 @@ The ElevenLabs [Speech to Text (STT)](/docs/api-reference/speech-to-text) API tu
 - Generate transcripts for meetings and other audio or video recordings
 
 <CardGroup cols={2}>
-  <Card title="Developer tutorial" icon="duotone book-sparkles" href="/docs/cookbooks/speech-to-text/synchronous">
+  <Card
+    title="Developer tutorial"
+    icon="duotone book-sparkles"
+    href="/docs/cookbooks/speech-to-text/synchronous"
+  >
     Learn how to integrate speech to text into your application.
   </Card>
   <Card

--- a/fern/docs/pages/capabilities/speech-to-text.mdx
+++ b/fern/docs/pages/capabilities/speech-to-text.mdx
@@ -13,7 +13,7 @@ The ElevenLabs [Speech to Text (STT)](/docs/api-reference/speech-to-text) API tu
 - Generate transcripts for meetings and other audio or video recordings
 
 <CardGroup cols={2}>
-  <Card title="Developer quickstart" icon="duotone book-sparkles" href="/docs/quickstart">
+  <Card title="Developer tutorial" icon="duotone book-sparkles" href="/docs/cookbooks/speech-to-text/synchronous">
     Learn how to integrate speech to text into your application.
   </Card>
   <Card

--- a/fern/docs/pages/cookbooks/speech-to-text/synchronous.mdx
+++ b/fern/docs/pages/cookbooks/speech-to-text/synchronous.mdx
@@ -18,29 +18,29 @@ In this tutorial, you'll learn how to transcribe audio with the ElevenLabs SDK s
 
 Before you begin, make sure you have installed the ElevenLabs SDK.
 
-<CodeGroup>
-    ```bash Python
+<CodeBlock>
+    ```python title="Python"
     pip install elevenlabs
     ```
 
-    ```bash JavaScript
+    ```javascript title="JavaScript"
     npm install elevenlabs
     ```
 
-</CodeGroup>
+</CodeBlock>
 
 Additionally, install necessary packages to manage your environmental variables:
 
-<CodeGroup>
-    ```bash Python
+<CodeBlock>
+    ```python title="Python"
     pip install python-dotenv
     ```
 
-    ```bash JavaScript
+    ```javascript title="JavaScript"
     npm install dotenv
     ```
 
-</CodeGroup>
+</CodeBlock>
 
 Next, create a `.env` file in your project directory and fill it with your credentials like so:
 


### PR DESCRIPTION
Link directly to the cookbook instead of the quickstart. 