### PR TITLE
Fix 90s drum loop mp3 url

### DIFF
--- a/fern/docs/pages/capabilities/sound-effects.mdx
+++ b/fern/docs/pages/capabilities/sound-effects.mdx
@@ -86,7 +86,7 @@ The API also supports generation of musical components:
 
 <elevenlabs-audio-player
     audio-title="90s drum loop"
-    audio-src="ttps://github.com/elevenlabs/elevenlabs-docs/blob/main/fern/assets/audio/sfx-90s-drum-loop.mp3"
+    audio-src="https://github.com/elevenlabs/elevenlabs-docs/blob/main/fern/assets/audio/sfx-90s-drum-loop.mp3"
 />
 
 #### Audio Terminology


### PR DESCRIPTION
Fix a missing character in the url