### PR TITLE
Fix: broken link to dynamic variable page

### DIFF
--- a/fern/conversational-ai/pages/customization/overrides.mdx
+++ b/fern/conversational-ai/pages/customization/overrides.mdx
@@ -5,7 +5,7 @@ subtitle: Tailor each conversation with personalized context for each user.
 
 <Warning>
   While overrides are still supported for completely replacing system prompts or first messages, we
-  recommend using [Dynamic Variables](/docs/conversational-ai/customization/dynamic-variables) as
+  recommend using [Dynamic Variables](/docs/conversational-ai/customization/personalization/dynamic-variables) as
   the preferred way to customize your agent's responses and inject real-time data. Dynamic Variables
   offer better maintainability and a more structured approach to personalization.
 </Warning>


### PR DESCRIPTION
Fixing a broken link to the dynamic variables page