### PR TITLE
fix: add SEO optimised code snippet

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -47,7 +47,7 @@ navigation:
             icon: duotone rectangle-history
       - section: CAPABILITIES
         contents:
-          - page: Text to speech
+          - page: Text to Speech
             path: docs/pages/capabilities/text-to-speech.mdx
           - page: Speech to Text
             path: docs/pages/capabilities/speech-to-text.mdx

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/framer.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/framer.mdx
@@ -12,6 +12,10 @@ subtitle: Integrate Audio Native into your Framer websites.
     <Step title="Add Audio Native script to your page">
         Navigate to your Framer page, sign in and go to your site settings. From the Audio Native embed code, extract the `<script>` tag and paste it in the "End of `<body>` tag" field.
 
+        ```html title="Embed script "
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
+
         <img
             src="/assets/images/product-guides/audio-native/audio-native-framer-1.webp"
             alt="Audio Native"
@@ -28,6 +32,21 @@ subtitle: Integrate Audio Native into your Framer websites.
         />
 
         In the config for the Embed Element, switch the type to HTML and paste the `<div>` snippet from the Audio Native embed code into the HTML box.
+
+        ```html title="Embed div"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+        ```
 
         <img
             src="/assets/images/product-guides/audio-native/audio-native-framer-3.webp"

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/ghost.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/ghost.mdx
@@ -23,6 +23,22 @@ subtitle: Integrate Audio Native into your Ghost blog.
 
         Paste the Audio Native embed code into the HTML box and press enter.
 
+        ```html title="Embed code snippet"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
+
         <img
             src="/assets/images/product-guides/audio-native/audio-native-ghost-2.webp"
             alt="Audio Native"

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/squarespace.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/squarespace.mdx
@@ -23,6 +23,22 @@ subtitle: Integrate Audio Native into your Squarespace sites.
 
         Paste the Audio Native embed code into the HTML box and press enter.
 
+        ```html title="Embed code snippet"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
+
         <img
             src="/assets/images/product-guides/audio-native/audio-native-squarespace-2.png"
             alt="Audio Native"

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/webflow.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/webflow.mdx
@@ -23,6 +23,22 @@ subtitle: Integrate Audio Native into your Webflow sites.
 
         Paste the Audio Native embed code into the HTML box and click "Save & Close".
 
+        ```html title="Embed code snippet"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
+
         <img
             src="/assets/images/product-guides/audio-native/audio-native-webflow-2.webp"
             alt="Audio Native"

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/wix.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/wix.mdx
@@ -23,6 +23,22 @@ subtitle: Integrate Audio Native into your Wix sites.
 
         Paste the Audio Native embed code into the HTML box and click "Save".
 
+        ```html title="Embed code snippet"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
+
         <img
             src="/assets/images/product-guides/audio-native/audio-native-wix-2.webp"
             alt="Audio Native"

--- a/fern/docs/pages/product-guides/audio-tools/audio-native/wordpress.mdx
+++ b/fern/docs/pages/product-guides/audio-tools/audio-native/wordpress.mdx
@@ -14,6 +14,22 @@ subtitle: Integrate Audio Native into your WordPress sites.
     </Step>
     <Step title="Create a new code snippet">
         In the WordPress admin console, click on "Code Snippets". Add the Audio Native embed code to the new code snippet.
+        
+        ```html title="Embed code snippet"
+            <div
+                id="elevenlabs-audionative-widget"
+                data-height="90"
+                data-width="100%"
+                data-frameborder="no"
+                data-scrolling="no"
+                data-publicuserid="public-user-id"
+                data-playerurl="https://elevenlabs.io/player/index.html"
+                data-projectid="project-id"
+            >
+                Loading the <a href="https://elevenlabs.io/text-to-speech" target="_blank" rel="noopener">Elevenlabs Text to Speech</a> AudioNative Player...
+            </div>
+            <script src="https://elevenlabs.io/player/audioNativeHelper.js" type="text/javascript"></script>
+        ```
 
         <img
             src="/assets/images/product-guides/audio-native/audio-native-wordpress-1.webp"


### PR DESCRIPTION
adds a code snippet for users to copy and paste in the docs, with the seo link james wanted.
unfortunately we can't retroactively change links used so this will have to suffice

e.g: adds this to 
![CleanShot 2025-02-27 at 10 32 05@2x](https://github.com/user-attachments/assets/f76c1712-5c8a-429b-862f-33e6e7df1748)
/docs/product-guides/audio-tools/audio-native/squarespace