### PR TITLE
fix: add consumption note

### DIFF
--- a/fern/conversational-ai/pages/overview.mdx
+++ b/fern/conversational-ai/pages/overview.mdx
@@ -44,6 +44,12 @@ Altogether it is a highly composable AI Voice agent solution that can scale to t
   **Setup & Prompt Testing**: billed at half the cost.
 </Card>
 
+<Note>
+  Usage is billed to the account that created the agent. If authentication is not enabled, anybody
+  with your agent's id can connect to it and consume your credits. To protect against this, either
+  enable authentication for your agent or handle the agent id as a secret.
+</Note>
+
 ## Pricing tiers
 
 <Tabs>


### PR DESCRIPTION
based on #813 

adds this note below convai pricing docs.
![CleanShot 2025-03-01 at 12 54 46@2x](https://github.com/user-attachments/assets/0b09d182-7cc6-4f9b-b237-a36835f649c9)

todo:
 will add another separate PR which talks about agent auth which is linked to from this note.