### PR TITLE
Added missing comma

### DIFF
--- a/fern/conversational-ai/pages/guides/twilio-outbound-calling.mdx
+++ b/fern/conversational-ai/pages/guides/twilio-outbound-calling.mdx
@@ -247,7 +247,7 @@ fastify.register(async (fastifyInstance) => {
             dynamic_variables: {
               user_name: "Angelo",
               user_id: 1234,
-            }
+            },
             conversation_config_override: {
               agent: {
                 prompt: {


### PR DESCRIPTION
This comma was missing from the example set up, with it missing, the server does not run and crashes out.