### PR TITLE
Fix generators structure to suppress deprecation warning

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -1,9 +1,10 @@
 api:
-  - path: ./openapi.json
-    overrides: ./openapi-overrides.yml
-    settings:
-      use-title: false
-  - path: ./asyncapi.yml
+  specs:
+    - openapi: ./openapi.json
+      overrides: ./openapi-overrides.yml
+      settings:
+        title-as-schema-name: false
+    - asyncapi: ./asyncapi.yml
 groups:
   python-sdk:
     generators:

--- a/fern/apis/convai/generators.yml
+++ b/fern/apis/convai/generators.yml
@@ -1,3 +1,4 @@
 api:
-  - openapi.json
-  - asyncapi.yml
+  specs:
+    - openapi: ./openapi.json
+    - asyncapi: ./asyncapi.yml


### PR DESCRIPTION
New version of the fern CLI changed how generator.yml is structured, meaning we were getting a warning every time:

> Warnings for generators.yml:
  Using an array for "api" is deprecated. Please use "api.specs[].openapi", "api.specs[].asyncapi", or "api.specs[].proto" instead.
  
This fixes it.