### PR TITLE
Remove prohibited voice design terms

### DIFF
--- a/fern/docs/pages/product-guides/voices/voice-design.mdx
+++ b/fern/docs/pages/product-guides/voices/voice-design.mdx
@@ -37,14 +37,18 @@ After generating, you'll have the option to select and save one of the generatio
 
 | Type                   | Description                                                                                                                     | Example Prompts                                                                                                                                                                                                                                                                                                                                                                                  |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Realistic Voice Design | Create an original, realistic voice by specifying age, accent/nationality, gender, tone, pitch, intonation, speed, and emotion. | - "A young Indian female with a soft, high voice. Conversational, slow and calm."<br></br> - "An old British male with a raspy, deep voice. Professional, relaxed and assertive."<br></br> - "A middle-aged Australian female with a warm, low voice. Corporate, fast and happy."                                                                                                                |
-| Character Voice Design | Generate unique voices for creative characters using simpler prompts.                                                           | - "A massive evil ogre, troll"<br></br>- "A sassy little squeaky mouse"<br></br>- "An angry old pirate, shouting" <br></br><br></br> Some other characters we've had success with include Goblin, Vampire, Elf, Troll, Werewolf, Ghost, Alien, Giant, Witch, Wizard, Zombie, Demon, Devil, Pirate, Genie, Ogre, Orc, Knight, Samurai, Banshee, Yeti, Druid, Robot, Elf, Monkey, Monster, Dracula |
+| Realistic Voice Design | Create an original, realistic voice by specifying age, accent/nationality, gender, tone, pitch, intonation, speed, and emotion. | - "An Indian woman with a soft, high voice. Conversational, slow and calm."<br></br> - "An old British male with a raspy, deep voice. Professional, relaxed and assertive."<br></br> - "A middle-aged Australian female with a warm, low voice. Corporate, fast and happy."                                                                                                                |
+| Character Voice Design | Generate unique voices for creative characters using simpler prompts.                                                           | - "A massive evil ogre, troll"<br></br>- "A cute little squeaky mouse"<br></br>- "An angry old pirate, shouting" <br></br><br></br> Some other characters we've had success with include Goblin, Vampire, Elf, Troll, Werewolf, Ghost, Alien, Giant, Witch, Wizard, Zombie, Demon, Devil, Pirate, Genie, Ogre, Orc, Knight, Samurai, Banshee, Yeti, Druid, Robot, Elf, Monkey, Monster, Dracula |
+
+<Warning>
+  Generating child or child-like voices violates our [Prohibited Use Policy](https://elevenlabs.io/use-policy).
+</Warning>
 
 ### Voice attributes
 
 | Attribute          | Importance      | Options                                                             |
 | :----------------- | :-------------- | :------------------------------------------------------------------ |
-| Age                | High Importance | Young, Teenage, Adult, Middle-Aged, Old, etc...                     |
+| Age                | High Importance | Adult, Middle-Aged, Old, etc...                     |
 | Accent/Nationality | High Importance | British, Indian, Polish, American, etc...                           |
 | Gender             | High Importance | Male, Female, Gender Neutral                                        |
 | Tone               | Not Needed      | Gruff, Soft, Warm, Raspy, etc...                                    |


### PR DESCRIPTION
Generating child or child-like voices is prohibited, so removing example prompts like "young" or "teenage" as those will be blocked. Also adds a warning about the above.