### PR TITLE
Fix duplicated ConvAI widget

### DIFF
--- a/fern/assets/scripts/widget.js
+++ b/fern/assets/scripts/widget.js
@@ -1,4 +1,11 @@
+const ID = 'elevenlabs-convai-widget-60993087-3f3e-482d-9570-cc373770addc';
+
 function injectElevenLabsWidget() {
+  // Check if the widget is already loaded
+  if (document.getElementById(ID)) {
+    return;
+  }
+
   const script = document.createElement('script');
   script.src = 'https://elevenlabs.io/convai-widget/index.js';
   script.async = true;
@@ -10,6 +17,7 @@ function injectElevenLabsWidget() {
   wrapper.className = 'desktop';
 
   const widget = document.createElement('elevenlabs-convai');
+  widget.id = ID;
   widget.setAttribute('agent-id', 'OZmXb9pmFsSkDE5dukJv');
   widget.setAttribute('variant', 'full');
 
@@ -51,19 +59,6 @@ function injectElevenLabsWidget() {
       widget.setAttribute('avatar-orb-color-2', '#9CE6E6');
     }
   }
-
-  widget.innerHTML = `\
-  <form slot="terms" class="prose text-sm">
-    <h3>Terms and conditions</h3>
-    <p>
-      By clicking "Continue," and each time I interact with this AI agent, I 
-      consent to ElevenLabs collecting and using my voice and data derived from 
-      it to interpret my speech, and provide the support services I request, and 
-      to the recording, storage, and sharing of my communications with 
-      third-party service providers, and as described in the 
-      <a href="/terms-of-use">Privacy Policy</a>. If you do not wish to have 
-      your conversations recorded, please refrain from using this service.
-  </form>`;
 
   // Listen for the widget's "call" event to inject client tools
   widget.addEventListener('elevenlabs-convai:call', (event) => {


### PR DESCRIPTION
Under some circumstances, the agent performing a redirect causes the init script to execute again, duplicating the widget on our website

Also removes the hardcoded terms since those are now configured via the agent config.