### PR TITLE
Add required type field to example at twilio-inbound-integration.mdx

### DIFF
--- a/fern/conversational-ai/pages/customization/dynamic-variables/twilio-inbound-integration.mdx
+++ b/fern/conversational-ai/pages/customization/dynamic-variables/twilio-inbound-integration.mdx
@@ -88,6 +88,7 @@ An example response could be:
 
 ```json
 {
+  "type": "conversation_initiation_client_data",
   "dynamic_variables": {
     "customer_name": "John Doe",
     "account_status": "premium",


### PR DESCRIPTION
I believe type field should be part of the example json as the API docs requires it: https://elevenlabs.io/docs/conversational-ai/api-reference/conversational-ai/websocket#send.Conversation%20Initiation%20Client%20Data

Twilio call fails without visible errors if users set up Client Initiation Webhook without this attribute. Personally spent hours trying to debug it after following the tutorial. Either this or a better error handling for the Client Initiation Webhook is needed.