### PR TITLE
Fix typo in dynamic variables documentation

### DIFF
--- a/fern/conversational-ai/pages/customization/dynamic-variables.mdx
+++ b/fern/conversational-ai/pages/customization/dynamic-variables.mdx
@@ -36,7 +36,7 @@ Your agent has access to these automatically available system variables:
 - `system__call_duration_secs` - Call duration in seconds
 - `system__time_utc` - Current UTC time (ISO format)
 - `system__conversation_id` - ElevenLabs' unique conversation identifier
-- `system__call_id` - Call SID (twilio calls only)
+- `system__call_sid` - Call SID (twilio calls only)
 
 System variables:
 


### PR DESCRIPTION
Typo error on the name of the dynamic variable (Conversation AI), `system__call_id` should be `system__call_sid`.
<br/>


Screenshot from the docs:
![image](https://github.com/user-attachments/assets/575d4fa6-6d89-4e30-9417-400f906f6acc)


Screenshot from the playground:
![image](https://github.com/user-attachments/assets/94f17805-b79b-4686-990a-3a8d61f1a7a4)
