### PR TITLE
Fix convai widget override examples

### DIFF
--- a/fern/conversational-ai/pages/customization/overrides.mdx
+++ b/fern/conversational-ai/pages/customization/overrides.mdx
@@ -144,6 +144,7 @@ This guide will show you how to override the default agent **System prompt** & *
 
     ```html title="Widget"
       <elevenlabs-convai
+        agent-id="your-agent-id"
         override-language="es"
         override-prompt="Custom system prompt for this user"
         override-first-message="Hi! How can I help you today?"

--- a/fern/conversational-ai/pages/customization/overrides.mdx
+++ b/fern/conversational-ai/pages/customization/overrides.mdx
@@ -143,21 +143,12 @@ This guide will show you how to override the default agent **System prompt** & *
     ```
 
     ```html title="Widget"
-    <elevenlabs-convai
-
-agent-id="your-agent-id"
-override-config='{
-"agent": {
-"prompt": {
-"prompt": "Custom system prompt for this user"
-},
-"first_message": "Hi! How can I help you today?",
-"language": "es"
-}
-}'
-
-> </elevenlabs-convai>
-
+      <elevenlabs-convai
+        override-language="es"
+        override-prompt="Custom system prompt for this user"
+        override-first-message="Hi! How can I help you today?"
+        override-voice-id="axXgspJ2msm3clMCkdW3"
+      ></elevenlabs-convai>
     ```
 
     </CodeGroup>

--- a/fern/conversational-ai/pages/customization/widget.mdx
+++ b/fern/conversational-ai/pages/customization/widget.mdx
@@ -97,16 +97,10 @@ Overrides enable complete customization of your agent's behavior at runtime:
 
 ```html
 <elevenlabs-convai
-  agent-id="your-agent-id"
-  override-config='{
-    "agent": {
-      "prompt": {
-        "prompt": "Custom system prompt for this user"
-      },
-      "first_message": "Hi! How can I help you today?",
-      "language": "es"
-    }
-  }'
+  override-language="es"
+  override-prompt="Custom system prompt for this user"
+  override-first-message="Hi! How can I help you today?"
+  override-voice-id="axXgspJ2msm3clMCkdW3"
 ></elevenlabs-convai>
 ```
 

--- a/fern/conversational-ai/pages/customization/widget.mdx
+++ b/fern/conversational-ai/pages/customization/widget.mdx
@@ -97,6 +97,7 @@ Overrides enable complete customization of your agent's behavior at runtime:
 
 ```html
 <elevenlabs-convai
+  agent-id="your-agent-id"
   override-language="es"
   override-prompt="Custom system prompt for this user"
   override-first-message="Hi! How can I help you today?"


### PR DESCRIPTION
Updates the override examples for the convai widget.

The `override-config` is an attribute (with a confusing name) used for dev purposes to override the entire config of the widget, not the agent overrides.

https://github.com/elevenlabs/xi/pull/9386 introduces a proper way to configure those overrides ~~so lets wait till that goes live and update the docs~~ it's live now so we can update the docs