### PR TITLE
Adding security best practises in docs yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -166,6 +166,8 @@ navigation:
                 path: docs/pages/best-practices/prompting/normalization.mdx
           - page: Latency optimization
             path: docs/pages/best-practices/latency-optimization.mdx
+          - page: Security
+            path: docs/pages/best-practices/security-best-practices.mdx
       - section: PRODUCT GUIDES
         skip-slug: false
         contents:


### PR DESCRIPTION
Correcting past omission which meant that security best practises page was not showing.

Original PR: https://github.com/elevenlabs/elevenlabs-docs/pull/1064 