### PR TITLE
Fix API client error handling

### DIFF
--- a/examples/elevenlabs-nextjs/app/actions/utils.ts
+++ b/examples/elevenlabs-nextjs/app/actions/utils.ts
@@ -7,9 +7,11 @@ import { Err, Ok, Result } from '@/types';
 export async function getElevenLabsClient(): Promise<Result<ElevenLabsClient>> {
   try {
     const userKeyResult = await getApiKey();
-    const userApiKey = userKeyResult.ok ? userKeyResult.value : null;
+    if (!userKeyResult.ok) {
+      return Err(userKeyResult.error);
+    }
 
-    const apiKey = userApiKey || env.ELEVENLABS_API_KEY;
+    const apiKey = userKeyResult.value || env.ELEVENLABS_API_KEY;
 
     if (!apiKey) {
       return Err(


### PR DESCRIPTION
## Summary
- handle errors from `getApiKey` when creating an ElevenLabs client

## Testing
- `pnpm run ci`

------
https://chatgpt.com/codex/tasks/task_b_68415949578c8325b032a3874639aa24