### PR TITLE
Update generators and mark api key as required

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -9,7 +9,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.20.2
+        version: 4.21.4
         output:
           location: pypi
           package-name: elevenlabs

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -1,7 +1,6 @@
 x-fern-global-headers:
   - header: xi-api-key
     name: api-key
-    optional: true
     env: ELEVENLABS_API_KEY
 servers:
   - url: https://api.elevenlabs.io/

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -628,7 +628,7 @@ navigation:
                 title: Agent WebSockets
                 slug: websocket
             snippets:
-              typescript: elevenlabs
+              typescript: "@elevenlabs/elevenlabs-js"
               python: elevenlabs
           - api: API Reference
             api-name: api
@@ -636,7 +636,7 @@ navigation:
             flattened: true
             paginated: true
             snippets:
-              typescript: elevenlabs
+              typescript: "@elevenlabs/elevenlabs-js"
               python: elevenlabs
             audiences:
               - convai
@@ -785,7 +785,7 @@ navigation:
           - no-audience
         snippets:
           python: elevenlabs
-          typescript: elevenlabs
+          typescript: "@elevenlabs/elevenlabs-js"
         layout:
           - page: Introduction
             path: api-reference/pages/introduction.mdx
@@ -800,7 +800,7 @@ navigation:
         alphabetized: false
         snippets:
           python: elevenlabs
-          typescript: elevenlabs
+          typescript: "@elevenlabs/elevenlabs-js"
         layout:
           - section: ENDPOINTS
             skip-slug: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "elevenlabs",
-  "version": "0.63.19"
+  "version": "0.63.38"
 }


### PR DESCRIPTION
Fixes:

* Incorrect import in TS snippets
* Marks API key as required instead of optional
* Upgrades fern and its generators