### PR TITLE
chore: decrease generation time for preview links

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_API_KEY }}
         run: |
-          OUTPUT=$(pnpm dlx fern-api generate --docs --preview) || true
+          OUTPUT=$(pnpm dlx fern-api generate --docs --preview --disable-snippets) || true
           echo "$OUTPUT"
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
           echo "Preview URL: $URL"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "elevenlabs",
-  "version": "0.63.38"
+  "version": "0.64.10"
 }


### PR DESCRIPTION
This PR adds a configuration to the preview generation CI to use the `--disable-snippets` flag on preview link generation. This removes snippets from the generated link, which is the main culprit of the slow load times. 