### PR TITLE
Add batch calls concurrency info

### DIFF
--- a/fern/conversational-ai/pages/guides/batch-calls.mdx
+++ b/fern/conversational-ai/pages/guides/batch-calls.mdx
@@ -33,6 +33,11 @@ This feature is available for both phone numbers added via the [native Twilio in
 - **Real-time monitoring**: Track the progress of your batch calls, including overall status and individual call status.
 - **Detailed reporting**: View comprehensive details of completed batch calls, including individual call recipient information.
 
+## Concurrency
+
+When batch calls are initiated, they automatically utilize up to 70% of your plan's concurrency limit. 
+This leaves 30% of your concurrent capacity available for other conversations, including incoming calls and calls via the widget.
+
 ## Requirements
 
 - An ElevenLabs account with an [agent setup](/app/conversational-ai).

--- a/fern/conversational-ai/pages/guides/batch-calls.mdx
+++ b/fern/conversational-ai/pages/guides/batch-calls.mdx
@@ -35,7 +35,7 @@ This feature is available for both phone numbers added via the [native Twilio in
 
 ## Concurrency
 
-When batch calls are initiated, they automatically utilize up to 70% of your plan's concurrency limit. 
+When batch calls are initiated, they automatically utilize up to 70% of your plan's concurrency limit.
 This leaves 30% of your concurrent capacity available for other conversations, including incoming calls and calls via the widget.
 
 ## Requirements


### PR DESCRIPTION
Added concurrency information for batch calls - they use up to 70% of plan limits.