### PR TITLE
fix: capitalize tags for errant section names

### DIFF
--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -737,7 +737,7 @@
           }
         },
         "tags": [
-          "samples"
+          "Samples"
         ],
         "x-fern-sdk-group-name": "samples",
         "x-fern-sdk-method-name": "delete"
@@ -815,7 +815,7 @@
           }
         },
         "tags": [
-          "samples"
+          "Samples"
         ],
         "x-fern-sdk-group-name": [
           "voices",
@@ -2405,7 +2405,7 @@
           }
         },
         "tags": [
-          "user"
+          "User"
         ],
         "x-fern-sdk-group-name": [
           "user",
@@ -2462,7 +2462,7 @@
           }
         },
         "tags": [
-          "user"
+          "User"
         ],
         "x-fern-sdk-group-name": "user",
         "x-fern-sdk-method-name": "get"
@@ -8033,9 +8033,9 @@
           }
         },
         "tags": [
-          "models"
+          "Models"
         ],
-        "x-fern-sdk-group-name": "models",
+        "x-fern-sdk-group-name": "Models",
         "x-fern-sdk-method-name": "list"
       }
     },
@@ -8843,7 +8843,7 @@
           }
         },
         "tags": [
-          "usage"
+          "Usage"
         ],
         "x-fern-sdk-group-name": "usage",
         "x-fern-sdk-method-name": "get"
@@ -9468,8 +9468,7 @@
           }
         },
         "tags": [
-          "workspace",
-          "workspace"
+          "Workspace"
         ]
       }
     },
@@ -9536,7 +9535,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9614,7 +9613,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9693,7 +9692,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9761,7 +9760,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9828,7 +9827,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9895,7 +9894,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -9962,7 +9961,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -10007,7 +10006,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -10085,7 +10084,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -10161,7 +10160,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -10237,7 +10236,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": [
           "workspace",
@@ -10274,8 +10273,7 @@
           }
         },
         "tags": [
-          "workspace",
-          "workspace"
+          "Workspace"
         ]
       },
       "post": {
@@ -10313,8 +10311,7 @@
           }
         },
         "tags": [
-          "workspace",
-          "workspace"
+          "Workspace"
         ]
       }
     },
@@ -10350,8 +10347,7 @@
           }
         },
         "tags": [
-          "workspace",
-          "workspace"
+          "Workspace"
         ]
       }
     },
@@ -10418,7 +10414,7 @@
           }
         },
         "tags": [
-          "workspace"
+          "Workspace"
         ],
         "x-fern-sdk-group-name": "webhooks",
         "x-fern-sdk-method-name": "list"

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -8035,7 +8035,7 @@
         "tags": [
           "Models"
         ],
-        "x-fern-sdk-group-name": "Models",
+        "x-fern-sdk-group-name": "models",
         "x-fern-sdk-method-name": "list"
       }
     },


### PR DESCRIPTION
## Changes
- Capitalize tag names that were being used for the display name of some docs sections

Before:
![image](https://github.com/user-attachments/assets/1b93cc55-800e-461c-b8ae-5b97cea03af5)
After:
<img width="192" alt="image" src="https://github.com/user-attachments/assets/cf6e65e8-94c2-4105-8a55-045fd75061c5" />
