### PR TITLE
added import os to the quickstart guide

### DIFF
--- a/examples/snippets/python/quickstart_tts.py
+++ b/examples/snippets/python/quickstart_tts.py
@@ -1,12 +1,15 @@
 from dotenv import load_dotenv
 from elevenlabs.client import ElevenLabs
 from elevenlabs import play
+import os
 
 load_dotenv()
 
-client = ElevenLabs() # Defaults to ELEVENLABS_API_KEY
+elevenlabs = ElevenLabs(
+  api_key=os.getenv("ELEVENLABS_API_KEY"),
+)
 
-audio = client.text_to_speech.convert(
+audio = elevenlabs.text_to_speech.convert(
     text="The first move is what sets everything in motion.",
     voice_id="JBFqnCBsd6RMkjVDRZzb",
     model_id="eleven_multilingual_v2",

--- a/fern/snippets/generated/quickstart_tts.mdx
+++ b/fern/snippets/generated/quickstart_tts.mdx
@@ -4,6 +4,7 @@
 from dotenv import load_dotenv
 from elevenlabs.client import ElevenLabs
 from elevenlabs import play
+import os
 
 load_dotenv()
 


### PR DESCRIPTION
Hi, 

I was playing around with your API quickstart in your docs and found a missing import in the python example snippet. 

I added the import to `quickstart_tts.py` and then ran `pnpm run snippets:generate` which generated the `quickstart_tts.mdx`.

While fixing this also noticed that there was a differente approach to initialising the client. 
```python
client = ElevenLabs()
```
versus
```python
elevenlabs = ElevenLabs(
  api_key=os.getenv("ELEVENLABS_API_KEY"),
)
```
I went with the latter since the first one didn't work locally.

Feel free to let me know if there are any mistakes. Looking forward to your comments 🙌

Cheers! 

