### PR TITLE
feat: upgrade to using claude 4 over claude 3.5

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1676,3 +1676,6 @@ redirects:
     destination: /docs/api-reference/voices/settings/get
   - source: /docs/voicelab/pre-made-voices
     destination: /docs/product-guides/voices/voice-library
+
+ai-search:
+  model: claude-4


### PR DESCRIPTION
Reasoning:
- Better performance during tool calls, Claude 3.5 consistently hallucinates when responding to the messages `pause` and `skip turn`, but Claude 4 does not do this.