### PR TITLE
Fix websockets URLs for each region

### DIFF
--- a/fern/apis/api/asyncapi.yml
+++ b/fern/apis/api/asyncapi.yml
@@ -7,12 +7,6 @@ info:
     name: MIT License
   version: 1.1.0
 
-servers:
-  WSS:
-    url: wss://api.elevenlabs.io
-    protocol: wss
-    description: AssemblyAI API
-
 tags:
   - name: textToSpeech
 

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -1,6 +1,6 @@
 servers:
-  - url: https://api.elevenlabs.io/
-    x-fern-server-name: Production
+  - x-fern-server-name: Production
+    url: https://api.elevenlabs.io/
     description: Production (default). Routed to the closest region.
   - url: https://api.us.elevenlabs.io/
     x-fern-server-name: Production US

--- a/fern/apis/convai/asyncapi.yml
+++ b/fern/apis/convai/asyncapi.yml
@@ -8,10 +8,22 @@ info:
   version: 1.1.0
 
 servers:
-  API:
+  Production:
     url: wss://api.elevenlabs.io
     protocol: wss
-    description: ElevenLabs WebSocket API endpoint for real-time communication
+    description: Production (default). Routed to the closest region.
+  Production-US:
+    url: wss://api.us.elevenlabs.io
+    protocol: wss
+    description: Production routed only to the US region.
+  Production-EU:
+    url: wss://api.eu.residency.elevenlabs.io
+    protocol: wss
+    description: Production route for customers with EU data residency.
+  Production-India:
+    url: wss://api.in.residency.elevenlabs.io
+    protocol: wss
+    description: Production route for customers with India data residency.
 
 tags:
   - name: conversationalAI

--- a/fern/apis/convai/openapi.json
+++ b/fern/apis/convai/openapi.json
@@ -4,14 +4,6 @@
     "title": "ElevenLabs Conversational AI WebSocket API",
     "version": "1.0.0"
   },
-  "servers": [
-    {
-      "url": "wss://api.elevenlabs.io",
-      "description": "Production WebSocket Server",
-      "protocol": "wss",
-      "x-fern-server-name": "Production"
-    }
-  ],
   "paths": {},
   "components": {}
 }


### PR DESCRIPTION
Switching the base url to a different region isn't working right now. Neither SDK nor FE:

https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input
https://elevenlabs.io/docs/conversational-ai/api-reference/conversational-ai/websocket
https://github.com/elevenlabs/elevenlabs-python/blob/main/src/elevenlabs/environment.py

This seem to fix the FE pages in the preview. Hopefully the SDK too.


