### PR TITLE
Update agent id documentation for clarity

### DIFF
--- a/fern/conversational-ai/pages/customization/dynamic-variables.mdx
+++ b/fern/conversational-ai/pages/customization/dynamic-variables.mdx
@@ -30,7 +30,8 @@ Here are a few examples where dynamic variables are useful:
 
 Your agent has access to these automatically available system variables:
 
-- `system__agent_id` - Unique agent identifier
+- `system__agent_id` - Unique identifier of the agent that initiated the conversation (stays stable throughout the conversation)
+- `system__current_agent_id` - Unique identifier of the currently active agent (changes after agent transfers)
 - `system__caller_id` - Caller's phone number (voice calls only)
 - `system__called_number` - Destination phone number (voice calls only)
 - `system__call_duration_secs` - Call duration in seconds


### PR DESCRIPTION
Update documentation to clarify `system__agent_id` and introduce `system__current_agent_id`.

This clarifies which agent ID to use depending on whether the original initiating agent or the currently active agent (after transfers) is needed.