### PR TITLE
Fixing audio codec sip guidance

### DIFF
--- a/fern/conversational-ai/pages/guides/sip-trunking.mdx
+++ b/fern/conversational-ai/pages/guides/sip-trunking.mdx
@@ -33,7 +33,8 @@ Before setting up SIP trunking, ensure you have:
 3. Administrator access to your SIP trunk configuration
 4. Appropriate firewall settings to allow SIP traffic
 5. **TLS Support**: For enhanced security, ensure your SIP trunk provider supports TLS transport
-6. **Audio codec compatibility**: Your system must support **48kHz audio** or be capable of resampling audio on your end, as ElevenLabs' SIP deployment outputs and receives audio at this sample rate. This is independent of any audio format configured on the agent for direct websocket connections.
+6. **Audio codec compatibility**: 
+Your system must support either G711 or G722  audio codecs or be capable of resampling audio on your end. ElevenLabs' SIP deployment outputs and receives audio at this sample rate. This is independent of any audio format configured on the agent for direct websocket connections.
 
 ## Setting up SIP trunking
 


### PR DESCRIPTION
Context: https://docs.google.com/document/d/1WhyYgcMWdv-vIPEm7s_4dyVmTt3mzDw_MNRW9crWrk4/edit?tab=t.0#heading=h.d836gdkygrb7

Open question on whether to communicate G711A is supported given functional testing shows that it works despite it not being part of livekit's supported codecs: https://github.com/livekit/sip/blob/main/pkg/sip/media_codecs.go