### PR TITLE
Fix agent response correction documentation

### DIFF
--- a/fern/apis/convai/asyncapi.yml
+++ b/fern/apis/convai/asyncapi.yml
@@ -517,15 +517,19 @@ components:
       properties:
         type:
           x-fern-type: literal<"agent_response_correction">
-        correction_event:
+        agent_response_correction_event:
           type: object
-          description: Correction event data
+          description: Agent response correction event data
           required:
-            - corrected_response
+            - original_agent_response
+            - corrected_agent_response
           properties:
-            corrected_response:
+            original_agent_response:
               type: string
-              description: The corrected text content replacing the previous response
+              description: The original agent response before correction
+            corrected_agent_response:
+              type: string
+              description: The corrected agent response after truncation or interruption
     VadScore:
       type: object
       description: Schema for Voice Activity Detection scoring data

--- a/fern/conversational-ai/pages/api-reference/websocket.mdx
+++ b/fern/conversational-ai/pages/api-reference/websocket.mdx
@@ -147,6 +147,14 @@ This example demonstrates how to implement a WebSocket-based conversational AI c
       };
     };
 
+    type AgentResponseCorrectionEvent = BaseEvent & {
+      type: "agent_response_correction";
+      agent_response_correction_event: {
+        original_agent_response: string;
+        corrected_agent_response: string;
+      };
+    };
+
     type AudioResponseEvent = BaseEvent & {
       type: "audio";
       audio_event: {
@@ -173,6 +181,7 @@ This example demonstrates how to implement a WebSocket-based conversational AI c
     export type ElevenLabsWebSocketEvent =
       | UserTranscriptEvent
       | AgentResponseEvent
+      | AgentResponseCorrectionEvent
       | AudioResponseEvent
       | InterruptionEvent
       | PingEvent;
@@ -244,6 +253,11 @@ This example demonstrates how to implement a WebSocket-based conversational AI c
           if (data.type === "agent_response") {
             const { agent_response_event } = data;
             console.log("Agent response", agent_response_event.agent_response);
+          }
+
+          if (data.type === "agent_response_correction") {
+            const { agent_response_correction_event } = data;
+            console.log("Agent response correction", agent_response_correction_event.corrected_agent_response);
           }
 
           if (data.type === "interruption") {


### PR DESCRIPTION
Correct `agent_response_correction` event structure in AsyncAPI schema and add WebSocket API reference examples to match the actual received model.

The `asyncapi.yml` documentation for the `agent_response_correction` event was outdated, using `correction_event` and a single `corrected_response` field, while the actual event received by clients uses `agent_response_correction_event` with `original_agent_response` and `corrected_agent_response`. This PR updates the schema and adds corresponding TypeScript types and handler examples to the WebSocket API reference to reflect the correct, implemented structure, resolving user confusion.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1754031028196179?thread_ts=1754031028.196179&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-65c44bd2-74fe-4b25-8c3b-5946c22f9824">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-65c44bd2-74fe-4b25-8c3b-5946c22f9824">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>