### PR TITLE
Update text normalization parameter documentation

### DIFF
--- a/fern/apis/api/asyncapi.yml
+++ b/fern/apis/api/asyncapi.yml
@@ -818,8 +818,7 @@ components:
       description: >-
         This parameter controls text normalization with three modes - 'auto', 'on', and 'off'. When set to 'auto',
         the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on',
-        text normalization will always be applied, while with 'off', it will be skipped. Cannot be turned on for
-        'eleven_turbo_v2_5' or 'eleven_flash_v2_5' models. Defaults to 'auto'.
+        text normalization will always be applied, while with 'off', it will be skipped. Defaults to 'auto'.
       type: string
       enum: ['auto', 'on', 'off']
       default: 'auto'

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -20940,7 +20940,7 @@
             "title": "Use Pvc As Ivc"
           },
           "apply_text_normalization": {
-            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped. Cannot be turned on for 'eleven_turbo_v2_5' or 'eleven_flash_v2_5' models.",
+            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped.",
             "type": "string",
             "default": "auto",
             "enum": [
@@ -21131,7 +21131,7 @@
             "title": "Use Pvc As Ivc"
           },
           "apply_text_normalization": {
-            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped. Cannot be turned on for 'eleven_turbo_v2_5' or 'eleven_flash_v2_5' models.",
+            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped.",
             "type": "string",
             "default": "auto",
             "enum": [
@@ -21322,7 +21322,7 @@
             "title": "Use Pvc As Ivc"
           },
           "apply_text_normalization": {
-            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped. Cannot be turned on for 'eleven_turbo_v2_5' or 'eleven_flash_v2_5' models.",
+            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped.",
             "type": "string",
             "default": "auto",
             "enum": [
@@ -21492,7 +21492,7 @@
             "title": "Use Pvc As Ivc"
           },
           "apply_text_normalization": {
-            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped. Cannot be turned on for 'eleven_turbo_v2_5' or 'eleven_flash_v2_5' models.",
+            "description": "This parameter controls text normalization with three modes: 'auto', 'on', and 'off'. When set to 'auto', the system will automatically decide whether to apply text normalization (e.g., spelling out numbers). With 'on', text normalization will always be applied, while with 'off', it will be skipped.",
             "type": "string",
             "default": "auto",
             "enum": [

--- a/fern/docs/pages/changelog/2024-10-20.md
+++ b/fern/docs/pages/changelog/2024-10-20.md
@@ -1,6 +1,6 @@
 ## API
 
-- **Normalize Text with the API**: Added the option normalize the input text in the TTS API. The new parameter is called `apply_text_normalization` and works on all non-turbo & non-flash models.
+- **Normalize Text with the API**: Added the option normalize the input text in the TTS API. The new parameter is called `apply_text_normalization` and works on all models.
 
 ## Product
 

--- a/fern/docs/pages/models.mdx
+++ b/fern/docs/pages/models.mdx
@@ -119,13 +119,13 @@ With its lower price point and 75ms latency, Flash v2.5 is the cost-effective op
 
 <AccordionGroup>
   <Accordion title="Text normalization with numbers">
-    When using Flash v2.5, numbers aren't normalized in a way you might expect. For example, phone numbers might be read out in way that isn't clear for the user. Dates and currencies are affected in a similar manner.
+    When using Flash v2.5, numbers aren't normalized by default in a way you might expect. For example, phone numbers might be read out in way that isn't clear for the user. Dates and currencies are affected in a similar manner.
 
-    This is expected as normalization is disabled for Flash v2.5 to maintain the low latency.
+    By default, normalization is disabled for Flash v2.5 to maintain the low latency. However, you can now enable text normalization for v2.5 models by setting the `apply_text_normalization` parameter to "on" in your request.
 
     The Multilingual v2 model does a better job of normalizing numbers, so we recommend using it for phone numbers and other cases where number normalization is important.
 
-    For low-latency or Conversational AI applications, best practice is to have your LLM [normalize the text](/docs/best-practices/prompting/normalization) before passing it to the TTS model.
+    For low-latency or Conversational AI applications, best practice is to have your LLM [normalize the text](/docs/best-practices/prompting/normalization) before passing it to the TTS model, or use the `apply_text_normalization` parameter.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Update documentation to reflect that `apply_text_normalization` can now be enabled for v2.5 models.

The previous documentation explicitly stated that text normalization could not be turned on for `eleven_turbo_v2_5` or `eleven_flash_v2_5` models. This PR updates the API specifications and user-facing documentation to reflect the new functionality where passing "on" for the parameter enables text normalization for these models.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1754252530460729?thread_ts=1754252530.460729&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-51065391-f5c9-4aa6-9f83-67dbd82beda9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51065391-f5c9-4aa6-9f83-67dbd82beda9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>