### PR TITLE
Fix documentation typo in webhook parameter

### DIFF
--- a/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
+++ b/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
@@ -68,7 +68,7 @@ When a transcription is completed, ElevenLabs will send a POST request to your s
             model_id="scribe_v1",
             webhook=True,
           )
-          print(f"Transcription started: {result.task_id}")
+          print(f"Transcription started: {result.request_id}")
           return result
         except Exception as e:
           print(f"Error starting transcription: {e}")
@@ -89,7 +89,7 @@ When a transcription is completed, ElevenLabs will send a POST request to your s
             webhook: true,
           });
 
-          console.log('Transcription started:', result.task_id);
+          console.log('Transcription started:', result.requestId);
           return result;
         } catch (error) {
           console.error('Error starting transcription:', error);
@@ -169,16 +169,16 @@ app.post('/webhook/speech-to-text', (req, res) => {
     }
 
     if (event.type === 'speech_to_text.completed') {
-      const { task_id, status, text, language_code } = event.data;
+      const { request_id, status, text, language_code } = event.data;
 
-      console.log(`Transcription ${task_id} completed`);
+      console.log(`Transcription ${request_id} completed`);
       console.log(`Language: ${language_code}`);
       console.log(`Text: ${text}`);
 
-      processTranscription(task_id, text, language_code);
+      processTranscription(request_id, text, language_code);
     } else if (status === 'failed') {
-      console.error(`Transcription ${task_id} failed`);
-      handleTranscriptionError(task_id);
+      console.error(`Transcription ${request_id} failed`);
+      handleTranscriptionError(request_id);
     }
 
     res.status(200).json({ received: true });
@@ -188,11 +188,11 @@ app.post('/webhook/speech-to-text', (req, res) => {
   }
 });
 
-async function processTranscription(task_id, text, language) {
+async function processTranscription(request_id, text, language) {
   console.log('Processing completed transcription...');
 }
 
-async function handleTranscriptionError(task_id) {
+async function handleTranscriptionError(request_id) {
   console.log('Handling transcription error...');
 }
 
@@ -261,6 +261,6 @@ async function testWebhook() {
     webhook: true,
   });
 
-  console.log('Test transcription started:', result.task_id);
+  console.log('Test transcription started:', result.requestId);
 }
 ```

--- a/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
+++ b/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
@@ -169,16 +169,16 @@ app.post('/webhook/speech-to-text', (req, res) => {
     }
 
     if (event.type === 'speech_to_text.completed') {
-      const { request_id, status, text, language_code } = event.data;
+      const { requestId, status, text, language_code } = event.data;
 
-      console.log(`Transcription ${request_id} completed`);
+      console.log(`Transcription ${requestId} completed`);
       console.log(`Language: ${language_code}`);
       console.log(`Text: ${text}`);
 
-      processTranscription(request_id, text, language_code);
+      processTranscription(requestId, text, language_code);
     } else if (status === 'failed') {
-      console.error(`Transcription ${request_id} failed`);
-      handleTranscriptionError(request_id);
+      console.error(`Transcription ${requestId} failed`);
+      handleTranscriptionError(requestId);
     }
 
     res.status(200).json({ received: true });
@@ -188,11 +188,11 @@ app.post('/webhook/speech-to-text', (req, res) => {
   }
 });
 
-async function processTranscription(request_id, text, language) {
+async function processTranscription(requestId, text, language) {
   console.log('Processing completed transcription...');
 }
 
-async function handleTranscriptionError(request_id) {
+async function handleTranscriptionError(requestId) {
   console.log('Handling transcription error...');
 }
 

--- a/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
+++ b/fern/docs/pages/developer-guides/cookbooks/speech-to-text/webhooks.mdx
@@ -89,7 +89,7 @@ When a transcription is completed, ElevenLabs will send a POST request to your s
             webhook: true,
           });
 
-          console.log('Transcription started:', result.taskId);
+          console.log('Transcription started:', result.task_id);
           return result;
         } catch (error) {
           console.error('Error starting transcription:', error);
@@ -188,11 +188,11 @@ app.post('/webhook/speech-to-text', (req, res) => {
   }
 });
 
-async function processTranscription(taskId, text, language) {
+async function processTranscription(task_id, text, language) {
   console.log('Processing completed transcription...');
 }
 
-async function handleTranscriptionError(taskId) {
+async function handleTranscriptionError(task_id) {
   console.log('Handling transcription error...');
 }
 


### PR DESCRIPTION
Correct `taskId` to `requestId` in speech-to-text webhook documentation, ensuring language-specific casing.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1754321160495319?thread_ts=1754321160.495319&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-88c6345f-d635-4197-8512-0933fa4eef00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88c6345f-d635-4197-8512-0933fa4eef00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>