### PR TITLE
Update language support copy

### DIFF
--- a/fern/snippets/v2-model-languages.mdx
+++ b/fern/snippets/v2-model-languages.mdx
@@ -1,3 +1,3 @@
-Our v2 models support 29 languages:
+Our multilingual v2 models support 29 languages:
 
 _English (USA, UK, Australia, Canada), Japanese, Chinese, German, Hindi, French (France, Canada), Korean, Portuguese (Brazil, Portugal), Italian, Spanish (Spain, Mexico), Indonesian, Dutch, Turkish, Filipino, Polish, Swedish, Bulgarian, Romanian, Arabic (Saudi Arabia, UAE), Czech, Greek, Finnish, Croatian, Malay, Slovak, Danish, Tamil, Ukrainian & Russian._


### PR DESCRIPTION
Clarify documentation copy to specify that only multilingual v2 models support 29 languages, avoiding confusion with monolingual Turbo V2.

The previous phrasing "Our v2 models support 29 languages" was ambiguous as it could imply both M2 and Turbo V2 models, despite Turbo V2 being monolingual. This led to user confusion, which this change resolves.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1754482823394479?thread_ts=1754482823.394479&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-6d5c9fb4-2744-49b3-8327-e30e1890d5b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d5c9fb4-2744-49b3-8327-e30e1890d5b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>