### PR TITLE
Fix documentation link

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -577,7 +577,7 @@ paths:
       x-fern-audiences:
         - convai
     post:
-      description: Upload a file or webpage URL to create a knowledge base document. <br> <Note> After creating the document, update the agent's knowledge base by calling [Update agent](/docs/conversational-ai/api-reference/agents/update-agent). </Note>
+      description: Upload a file or webpage URL to create a knowledge base document. <br> <Note> After creating the document, update the agent's knowledge base by calling [Update agent](/docs/api-reference/agents/update). </Note>
       deprecated: true
   /v1/convai/batch-calling/{batch_id}:
     get:


### PR DESCRIPTION
Update 'Update agent' link in deprecated 'Add To Knowledge Base' documentation to point to the correct API reference.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1754967695173509?thread_ts=1754967695.173509&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-101e34e9-facf-4e79-9917-0960e2f80500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-101e34e9-facf-4e79-9917-0960e2f80500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

