### PR TITLE
Update latency optimization docs with global TTS info

### DIFF
--- a/fern/docs/pages/best-practices/latency-optimization.mdx
+++ b/fern/docs/pages/best-practices/latency-optimization.mdx
@@ -82,10 +82,64 @@ For example, using Flash models with Websockets, you can expect the following TT
   Contact your sales representative to get onboarded to our European infrastructure.
 </Info>
 
-<Note>
-  We are actively working on deploying our models in Asia. These deployments will bring speeds
-  closer to those experienced by US and EU customers.
-</Note>
+### Global TTS API preview
+
+For users in Asia and other regions, we offer a global TTS API preview that provides improved latency by routing requests to the closest available region.
+
+To use the global TTS API preview, you can override the base URL in your requests:
+
+**Direct API calls:**
+
+```bash
+curl -X POST \
+  "https://api.asia.elevenlabs.io/v1/text-to-speech/{voice_id}" \
+  -H "Accept: audio/mpeg" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: YOUR_API_KEY" \
+  -d '{
+    "text": "Hello World!",
+    "model_id": "eleven_flash_v2_5"
+  }'
+```
+
+**Python SDK:**
+
+```python
+from elevenlabs import ElevenLabs
+
+client = ElevenLabs(
+    api_key="YOUR_API_KEY",
+    base_url="https://api.asia.elevenlabs.io"
+)
+
+audio = client.generate(
+    text="Hello World!",
+    voice="Brian",
+    model="eleven_flash_v2_5"
+)
+```
+
+**TypeScript SDK:**
+
+```typescript
+import { ElevenLabs } from 'elevenlabs';
+
+const elevenlabs = new ElevenLabs({
+  apiKey: 'YOUR_API_KEY',
+  baseURL: 'https://api.asia.elevenlabs.io',
+});
+
+const audio = await elevenlabs.generate({
+  text: 'Hello World!',
+  voice: 'Brian',
+  model_id: 'eleven_flash_v2_5',
+});
+```
+
+<Info>
+  The global TTS API preview is currently available for testing. Contact your sales representative
+  for production usage and availability in your region.
+</Info>
 
 ## Choose appropriate voices
 


### PR DESCRIPTION
Replace Asia deployment note with a 'Global TTS API preview' section to provide immediate instructions for improved latency in Asia.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1755594765833729?thread_ts=1755594765.833729&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-1795c111-0427-4383-8a1e-ed06ab8fd671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1795c111-0427-4383-8a1e-ed06ab8fd671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

