### PR TITLE
Fix outdated LLM cost mention

### DIFF
--- a/fern/conversational-ai/pages/customization/rag.mdx
+++ b/fern/conversational-ai/pages/customization/rag.mdx
@@ -60,7 +60,7 @@ This process ensures that relevant information to the user's query is passed to 
     - **Maximum document chunks**: Set the maximum amount of retrieved content per query
     - **Maximum vector distance**: Set the maximum distance between the query and the retrieved chunks
 
-    These parameters could impact latency. They also could impact LLM cost which in the future will be passed on to you.
+    These parameters could impact latency. They also could impact LLM cost.
     For example, retrieving more chunks increases cost.
     Increasing vector distance allows for more context to be passed, but potentially less relevant context.
     This may affect quality and you should experiment with different parameters to find the best results.


### PR DESCRIPTION
Remove outdated LLM cost pass-through mention from RAG documentation.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1755661792245789?thread_ts=1755661792.245789&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-501bcc7a-0869-41f4-b39c-c30b9ca88302">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-501bcc7a-0869-41f4-b39c-c30b9ca88302">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

