### PR TITLE
Add user timezone and non-utc time variables

### DIFF
--- a/fern/conversational-ai/pages/customization/dynamic-variables.mdx
+++ b/fern/conversational-ai/pages/customization/dynamic-variables.mdx
@@ -36,6 +36,8 @@ Your agent has access to these automatically available system variables:
 - `system__called_number` - Destination phone number (voice calls only)
 - `system__call_duration_secs` - Call duration in seconds
 - `system__time_utc` - Current UTC time (ISO format)
+- `system__time` - Current time in the specified timezone (ISO format)
+- `system__timezone` - User-provided timezone (must be valid for tzinfo)
 - `system__conversation_id` - ElevenLabs' unique conversation identifier
 - `system__call_sid` - Call SID (twilio calls only)
 


### PR DESCRIPTION
Add `system__time` and `system__timezone` to the documentation to reflect available system dynamic variables.

These variables were identified as missing from the documentation in a recent Slack thread, despite being in use.

---
[Slack Thread](https://eleven-labs-workspace.slack.com/archives/C06Q6PMDZ41/p1755729902658769?thread_ts=1755729902.658769&cid=C06Q6PMDZ41)

<a href="https://cursor.com/background-agent?bcId=bc-77880eb0-f898-4986-86b4-bab0e0a98ad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77880eb0-f898-4986-86b4-bab0e0a98ad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

